### PR TITLE
Updated :menuselection: arrow replacement patch:

### DIFF
--- a/userguide/conf.py
+++ b/userguide/conf.py
@@ -64,7 +64,7 @@ from sphinx.roles import _amp_re
 def patched_menusel_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     text = utils.unescape(text)
     if typ == 'menuselection':
-        text = text.replace('-->', u'\N{HEAVY WIDE-HEADED RIGHTWARDS ARROW}') # Here is the patch 
+        text = text.replace('-->', u'\u2192') # Here is the patch 
 
     spans = _amp_re.split(text)  
 


### PR DESCRIPTION
- Altered the patch to use unicode numbers instead of text names.
- Changed the arrow symbol to be as pdf generation friendly as possible.