### PR TITLE
Updates regarding SMB shares

### DIFF
--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1538,15 +1538,6 @@ a multiple of _SC_PAGESIZE (typically *4096*) to avoid memory
 fragmentation. This will increase Samba's memory requirements and
 should not be used on systems with limited RAM.
 
-To increase network performance, read the Samba section on socket
-options in the
-`smb.conf manual page
-<https://www.freebsd.org/cgi/man.cgi?query=smb.conf&manpath=FreeBSD+11.0-RELEASE+and+Ports>`_.
-It indicates which options are available and recommends that you
-experiment to see which are supported by your clients and improve your
-network's performance.
-#endif freenas
-
 Windows automatically caches file sharing information. If changes are
 made to an SMB share or to the permissions of a volume/dataset being
 shared by SMB and the share becomes inaccessible, try logging out and
@@ -1636,7 +1627,9 @@ unless there is a specific need.**
   back up the data, create a new case-insensitive dataset, create an
   SMB share on it, then copy the data from the old one onto it. After
   the data has been checked and verified on the new share, the old one
-  can be deleted.
+  can be deleted. Once the case-insensitive dataset is created, the
+  share level auxiliary parameter “case sensitive = true” can be safely
+  set.
 
 * If present, remove options for extended attributes and DOS
   attributes in the share's

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1415,9 +1415,9 @@ This configuration screen is really a front-end to
    |                                  |                | :guilabel:`Hosts Deny` fields of a SMB share; uncheck if IP addresses are used to avoid the           |
    |                                  |                | delay of a host lookup                                                                                |
    +----------------------------------+----------------+-------------------------------------------------------------------------------------------------------+
-   | Server minimum protocol          | drop-down menu | the minimum protocol version the server will support where the default sets automatic                 |
-   |                                  |                | negotiation; refer to :numref:`Table %s <smb_protocol_ver_tab>` for descriptions                      |
-   |                                  |                |                                                                                                       |
+   | Server minimum protocol          | drop-down menu | the minimum protocol version the server will allow the client to use. Default selects "LANMAN1". SMB  |
+   |                                  |                | clients will automatically negotiate the highest supported protocol version that meets or exceeds     |
+   |                                  |                | this value ; refer to :numref:`Table %s <smb_protocol_ver_tab>` for descriptions.                     |
    +----------------------------------+----------------+-------------------------------------------------------------------------------------------------------+
    | Server maximum protocol          | drop-down menu | the maximum protocol version the server will support; refer to                                        |
    |                                  |                | :numref:`Table %s <smb_protocol_ver_tab>` for descriptions                                            |
@@ -1484,7 +1484,7 @@ This configuration screen is really a front-end to
    | SMB2_10        | used by Windows 7                                          |
    |                |                                                            |
    +----------------+------------------------------------------------------------+
-   | SMB3           | used by Windows 8                                          |
+   | SMB3           | Same as SMB3_11                                            |
    |                |                                                            |
    +----------------+------------------------------------------------------------+
    | SMB3_00        | used by Windows 8                                          |
@@ -1498,7 +1498,8 @@ This configuration screen is really a front-end to
    +----------------+------------------------------------------------------------+
 
 
-Changes to SMB settings and SMB shares take effect immediately.
+Changes to SMB settings take effect immediately. Changes to share settings will not
+effect until the client and server negotiate a new session. 
 
 .. note:: Do not set the *directory name cache size* as an
    :guilabel:`Auxiliary parameter`. Due to differences in how Linux

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1415,9 +1415,9 @@ This configuration screen is really a front-end to
    |                                  |                | :guilabel:`Hosts Deny` fields of a SMB share; uncheck if IP addresses are used to avoid the           |
    |                                  |                | delay of a host lookup                                                                                |
    +----------------------------------+----------------+-------------------------------------------------------------------------------------------------------+
-   | Server minimum protocol          | drop-down menu | the minimum protocol version the server will allow the client to use; Default selects *LANMAN1*. SMB  |
-   |                                  |                | clients automatically negotiate the highest supported protocol version that meets or exceeds this     |
-   |                                  |                | value; refer to :numref:`Table %s <smb_protocol_ver_tab>` for descriptions                            |
+   | Server minimum protocol          | drop-down menu | the minimum protocol version the server will support; default selects *LANMAN1*; SMB clients          |
+   |                                  |                | automatically negotiate the highest supported protocol version that meets or exceeds this value;      |
+   |                                  |                | refer to :numref:`Table %s <smb_protocol_ver_tab>` for descriptions                                   |
    +----------------------------------+----------------+-------------------------------------------------------------------------------------------------------+
    | Server maximum protocol          | drop-down menu | the maximum protocol version the server will support; refer to                                        |
    |                                  |                | :numref:`Table %s <smb_protocol_ver_tab>` for descriptions                                            |

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1640,8 +1640,8 @@ unless there is a specific need.**
   overhead.
 
 
-  
-  
+
+
 .. index:: SNMP, Simple Network Management Protocol
 .. _SNMP:
 

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1415,9 +1415,9 @@ This configuration screen is really a front-end to
    |                                  |                | :guilabel:`Hosts Deny` fields of a SMB share; uncheck if IP addresses are used to avoid the           |
    |                                  |                | delay of a host lookup                                                                                |
    +----------------------------------+----------------+-------------------------------------------------------------------------------------------------------+
-   | Server minimum protocol          | drop-down menu | the minimum protocol version the server will allow the client to use. Default selects "LANMAN1". SMB  |
-   |                                  |                | clients will automatically negotiate the highest supported protocol version that meets or exceeds     |
-   |                                  |                | this value ; refer to :numref:`Table %s <smb_protocol_ver_tab>` for descriptions.                     |
+   | Server minimum protocol          | drop-down menu | the minimum protocol version the server will allow the client to use; Default selects *LANMAN1*. SMB  |
+   |                                  |                | clients automatically negotiate the highest supported protocol version that meets or exceeds this     |
+   |                                  |                | value; refer to :numref:`Table %s <smb_protocol_ver_tab>` for descriptions                            |
    +----------------------------------+----------------+-------------------------------------------------------------------------------------------------------+
    | Server maximum protocol          | drop-down menu | the maximum protocol version the server will support; refer to                                        |
    |                                  |                | :numref:`Table %s <smb_protocol_ver_tab>` for descriptions                                            |
@@ -1484,7 +1484,7 @@ This configuration screen is really a front-end to
    | SMB2_10        | used by Windows 7                                          |
    |                |                                                            |
    +----------------+------------------------------------------------------------+
-   | SMB3           | Same as SMB3_11                                            |
+   | SMB3           | used by Windows 10; same as SMB3_11                        |
    |                |                                                            |
    +----------------+------------------------------------------------------------+
    | SMB3_00        | used by Windows 8                                          |
@@ -1498,8 +1498,8 @@ This configuration screen is really a front-end to
    +----------------+------------------------------------------------------------+
 
 
-Changes to SMB settings take effect immediately. Changes to share settings will not
-effect until the client and server negotiate a new session. 
+Changes to SMB settings take effect immediately. Changes to share settings only take
+effect after the client and server negotiate a new session. 
 
 .. note:: Do not set the *directory name cache size* as an
    :guilabel:`Auxiliary parameter`. Due to differences in how Linux
@@ -1537,6 +1537,7 @@ performance in some configurations and can be added to the
 a multiple of _SC_PAGESIZE (typically *4096*) to avoid memory
 fragmentation. This will increase Samba's memory requirements and
 should not be used on systems with limited RAM.
+#endif freenas
 
 Windows automatically caches file sharing information. If changes are
 made to an SMB share or to the permissions of a volume/dataset being
@@ -1625,11 +1626,10 @@ unless there is a specific need.**
   This ZFS property is only available when creating a dataset. It
   cannot be changed on an existing dataset. To convert such datasets,
   back up the data, create a new case-insensitive dataset, create an
-  SMB share on it, then copy the data from the old one onto it. After
-  the data has been checked and verified on the new share, the old one
-  can be deleted. Once the case-insensitive dataset is created, the
-  share level auxiliary parameter “case sensitive = true” can be safely
-  set.
+  SMB share on it, set the share level auxiliary parameter 
+  *case sensitive = true*, then copy the data from the old one onto it. 
+  After the data has been checked and verified on the new share, the old 
+  one can be deleted.
 
 * If present, remove options for extended attributes and DOS
   attributes in the share's
@@ -1640,8 +1640,8 @@ unless there is a specific need.**
   overhead.
 
 
-
-
+  
+  
 .. index:: SNMP, Simple Network Management Protocol
 .. _SNMP:
 

--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -1057,9 +1057,9 @@ provides more details for each configurable option.
    |                              |               |          | file) are created; existing files are not affected                                                          |
    |                              |               |          |                                                                                                             |
    +------------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------+
-   | Allow Guest Access           | checkbox      |          | if checked, no password is required to connect to the share. User login attempts with a bad password are    |
+   | Allow Guest Access           | checkbox      |          | if checked, a password is not required to connect to the share; connections with a bad password are         |
    |                              |               |          | rejected unless the user account does not exist, in which case it is mapped to the guest account and        |
-   |                              |               |          | granted the permissions of the guest user defined in the :ref:`SMB` service.                                |
+   |                              |               |          | granted the permissions of the guest user defined in the :ref:`SMB` service                                 |
    +------------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------+
    | Only Allow Guest Access      | checkbox      | ✓        | requires :guilabel:`Allow guest access` to also be checked; forces guest access for all connections         |
    |                              |               |          |                                                                                                             |
@@ -1093,16 +1093,15 @@ settings:
   :menuselection:`Services --> SMB`.
 
 * When the :guilabel:`Browsable to Network Clients` box is checked (the 
-  default), the share will be visible in the server's browse list. If the share 
-  is is flagged as a :guilabel:`home share`, unchecking this box will hide the 
-  [homes] share so that only the dynamically generated home share with the
-  authenticated user's name will be visible (in contrast with [homes]
-  and [<username>] both being visible). 
-
-  The presence of a share in a user's browse list does not grant the user  
-  read or write permissions on the share. Users are still able to directly 
-  access and map shares that are not visible in the browse list by using 
-  the share's UNC path. Hence, this option is of limited security utility.
+  default), the share is visible when the user lists the available shares 
+  through Windows File Explorer or through the *net view* command. If the  
+  share is flagged as a :guilabel:`home share`, unchecking this box hides the 
+  *homes* share so that only the dynamically generated home share with the
+  authenticated username will be visible (in contrast with a share named
+  *homes* and the dynamically-generated home share both being visible). 
+  Users are not automatically granted read or write permissions on browsable
+  shares. This option provides no real security because shares that are not 
+  visible in Windows File Explorer can still be accessed with a *UNC* path.  
 
 * If some files on a shared volume should be hidden and inaccessible
   to users, put a *veto files=* line in the
@@ -1134,7 +1133,9 @@ like Windows 7 will not be able to connect with NTLMv1 disabled.
 `Security guidance for NTLMv1 and LM network authentication
 <https://support.microsoft.com/en-us/help/2793313/security-guidance-for-ntlmv1-and-lm-network-authentication>`_
 has information about the security implications and ways to enable
-NTLMv2.
+NTLMv2. If changing the client configuration is not possible, NTLMv1
+authentication can be enabled by checking the box :guilabel:`NTLMv1 auth` 
+in :menuselection:`Services --> SMB`.
 
 
 :numref:`Table %s <avail_vfs_modules_tab>`
@@ -1287,10 +1288,10 @@ for more details.
    | xattr_tdb           | stores Extended Attributes (EAs) in a tdb file so they can be used on filesystems which do not provide support for EAs                     |
    |                     |                                                                                                                                            |
    +---------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
-   | zfs_space           | correctly calculates ZFS space used by share, including space used by ZFS snapshots, quotas, and resevations. Enabled by default.          |
+   | zfs_space           | correctly calculates ZFS space used by share, including space used by ZFS snapshots, quotas, and resevations; enabled by default           |
    |                     |                                                                                                                                            |
    +---------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
-   | zfsacl              | provide ACL extensions for proper integration with ZFS. Enabled by default.                                                                |
+   | zfsacl              | provide ACL extensions for proper integration with ZFS; enabled by default                                                                 |
    |                     |                                                                                                                                            |
    +---------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 
@@ -1299,14 +1300,15 @@ for more details.
    sure to configure **all** SMB shares this way. Reboot the Mac
    client after making this change.
 
-These VFS objects do not appear in the drop-down menu and are dynamically
-configured:
+These VFS objects do not appear in the selection box:
 
 * **recycle:** moves deleted files to the recycle directory instead of
-  deleting them. Controlled by a checkbox in the share configuration.
+  deleting them. Controlled by :guilabel:`Export Recycle Bin`.
 
 * **shadow_copy2:** a more recent implementation of
-  :guilabel:`shadow_copy` with some additional features
+  :guilabel:`shadow_copy` with some additional features. *shadow_copy2*
+  and associated *shadow:* parameters are automatically added to the
+  :file:`smb4.conf` when a :guilabel:`Periodic Snapshot Task` is selected.
 
 
 .. _Configuring Unauthenticated Access:

--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -1057,9 +1057,9 @@ provides more details for each configurable option.
    |                              |               |          | file) are created; existing files are not affected                                                          |
    |                              |               |          |                                                                                                             |
    +------------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------+
-   | Allow Guest Access           | checkbox      |          | if checked, no password is required to connect to the share and all users share the permissions of the      |
-   |                              |               |          | guest user defined in the :ref:`SMB` service                                                                |
-   |                              |               |          |                                                                                                             |
+   | Allow Guest Access           | checkbox      |          | if checked, no password is required to connect to the share. User login attempts with a bad password are    |
+   |                              |               |          | rejected unless the user account does not exist, in which case it is mapped to the guest account and        |
+   |                              |               |          | granted the permissions of the guest user defined in the :ref:`SMB` service.                                |
    +------------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------+
    | Only Allow Guest Access      | checkbox      | ✓        | requires :guilabel:`Allow guest access` to also be checked; forces guest access for all connections         |
    |                              |               |          |                                                                                                             |
@@ -1093,15 +1093,16 @@ settings:
   :menuselection:`Services --> SMB`.
 
 * When the :guilabel:`Browsable to Network Clients` box is checked (the 
-  default), the share will be visible in the server's browse list. In the 
-  context of the special [homes] share, unchecking this box will hide the 
+  default), the share will be visible in the server's browse list. If the share 
+  is is flagged as a :guilabel:`home share’, unchecking this box will hide the 
   [homes] share so that only the dynamically generated home share with the
-  authenticated user's name [%U] will be visibile (in contrast with [homes]
-  and [%U] both being visible. The presence of a share in the user's browse 
-  list does not indicate that the user has read or write permissions on the 
-  share. Users are still able to directly access and map shares that are not 
-  visible in the browse list by using the share's UNC path. Hence, this option
-  is of limited security utility.
+  authenticated user's name will be visible (in contrast with [homes]
+  and [<username>] both being visible). 
+
+  The presence of a share in a user's browse list does not grant the user  
+  read or write permissions on the share. Users are still able to directly 
+  access and map shares that are not visible in the browse list by using 
+  the share's UNC path. Hence, this option is of limited security utility.
 
 * If some files on a shared volume should be hidden and inaccessible
   to users, put a *veto files=* line in the

--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -1094,7 +1094,7 @@ settings:
 
 * When the :guilabel:`Browsable to Network Clients` box is checked (the 
   default), the share will be visible in the server's browse list. If the share 
-  is is flagged as a :guilabel:`home share’, unchecking this box will hide the 
+  is is flagged as a :guilabel:`home share`, unchecking this box will hide the 
   [homes] share so that only the dynamically generated home share with the
   authenticated user's name will be visible (in contrast with [homes]
   and [<username>] both being visible). 

--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -1093,14 +1093,13 @@ settings:
   :menuselection:`Services --> SMB`.
 
 * When the :guilabel:`Browsable to Network Clients` box is checked (the
-  default), the share is visible when the user lists the available shares
-  through Windows File Explorer or through :command:`net view`. When the
-  :guilabel:`Use as a home share` box is checked, unchecking the
-  :guilabel:`Browsable to Network Clients` box hides the share named *homes*
-  so that only the dynamically generated share granting access to the
-  authenticated user's home directory will be visible (in contrast with a
-  share named *homes* and the home directory both being visible). Users are
-  not automatically granted read or write permissions on browsable shares.
+  default), the share is visible through Windows File Explorer or through 
+  :command:`net view`. When the :guilabel:`Use as a home share` box is 
+  checked, unchecking the :guilabel:`Browsable to Network Clients` box hides 
+  the share named *homes* so that only the dynamically generated share 
+  containing the authenticated user's home directory will be visible. By 
+  default, the *homes* share and the user's home directory are both visible.
+  Users are not automatically granted read or write permissions on browsable shares.
   This option provides no real security because shares that are not
   visible in Windows File Explorer can still be accessed with a *UNC* path.
 

--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -1286,26 +1286,26 @@ for more details.
    | xattr_tdb           | stores Extended Attributes (EAs) in a tdb file so they can be used on filesystems which do not provide support for EAs                     |
    |                     |                                                                                                                                            |
    +---------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
-
+   | zfs_space           | correctly calculates ZFS space used by share, including space used by ZFS snapshots, quotas, and resevations. Enabled by default.          |
+   |                     |                                                                                                                                            |
+   +---------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
+   | zfsacl              | provide ACL extensions for proper integration with ZFS. Enabled by default.                                                                |
+   |                     |                                                                                                                                            |
+   +---------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. note:: When using :guilabel:`fruit`, also add the
    :guilabel:`streams_xattr` and :guilabel:`catia` VFS objects and be
    sure to configure **all** SMB shares this way. Reboot the Mac
    client after making this change.
 
-These VFS objects do not appear in the drop-down menu as they are
-always enabled:
+These VFS objects do not appear in the drop-down menu and are dynamically
+configured:
 
 * **recycle:** moves deleted files to the recycle directory instead of
-  deleting them
+  deleting them. Controlled by a checkbox in the share configuration.
 
 * **shadow_copy2:** a more recent implementation of
   :guilabel:`shadow_copy` with some additional features
-
-* **zfs_space:** correctly calculates ZFS space used by share,
-  including any reservations or quotas
-
-* **zfsacl:** provide ACL extensions for proper integration with ZFS.
 
 
 .. _Configuring Unauthenticated Access:

--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -1092,16 +1092,17 @@ settings:
   in
   :menuselection:`Services --> SMB`.
 
-* When the :guilabel:`Browsable to Network Clients` box is checked (the 
-  default), the share is visible when the user lists the available shares 
-  through Windows File Explorer or through the *net view* command. If the  
-  share is flagged as a :guilabel:`home share`, unchecking this box hides the 
-  *homes* share so that only the dynamically generated home share with the
-  authenticated username will be visible (in contrast with a share named
-  *homes* and the dynamically-generated home share both being visible). 
-  Users are not automatically granted read or write permissions on browsable
-  shares. This option provides no real security because shares that are not 
-  visible in Windows File Explorer can still be accessed with a *UNC* path.  
+* When the :guilabel:`Browsable to Network Clients` box is checked (the
+  default), the share is visible when the user lists the available shares
+  through Windows File Explorer or through :command:`net view`. When the
+  :guilabel:`Use as a home share` box is checked, unchecking the
+  :guilabel:`Browsable to Network Clients` box hides the share named *homes*
+  so that only the dynamically generated share granting access to the
+  authenticated user's home directory will be visible (in contrast with a
+  share named *homes* and the home directory both being visible). Users are
+  not automatically granted read or write permissions on browsable shares.
+  This option provides no real security because shares that are not
+  visible in Windows File Explorer can still be accessed with a *UNC* path.
 
 * If some files on a shared volume should be hidden and inaccessible
   to users, put a *veto files=* line in the
@@ -1288,7 +1289,7 @@ for more details.
    | xattr_tdb           | stores Extended Attributes (EAs) in a tdb file so they can be used on filesystems which do not provide support for EAs                     |
    |                     |                                                                                                                                            |
    +---------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
-   | zfs_space           | correctly calculates ZFS space used by share, including space used by ZFS snapshots, quotas, and resevations; enabled by default           |
+   | zfs_space           | correctly calculates ZFS space used by the share, including space used by ZFS snapshots, quotas, and resevations; enabled by default       |
    |                     |                                                                                                                                            |
    +---------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
    | zfsacl              | provide ACL extensions for proper integration with ZFS; enabled by default                                                                 |
@@ -1303,11 +1304,12 @@ for more details.
 These VFS objects do not appear in the selection box:
 
 * **recycle:** moves deleted files to the recycle directory instead of
-  deleting them. Controlled by :guilabel:`Export Recycle Bin`.
+  deleting them. Controlled by :guilabel:`Export Recycle Bin` in the 
+  :ref:`SMB share configuration`.
 
 * **shadow_copy2:** a more recent implementation of
   :guilabel:`shadow_copy` with some additional features. *shadow_copy2*
-  and associated *shadow:* parameters are automatically added to the
+  and its associated parameters are automatically added to the
   :file:`smb4.conf` when a :guilabel:`Periodic Snapshot Task` is selected.
 
 

--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -1092,16 +1092,16 @@ settings:
   in
   :menuselection:`Services --> SMB`.
 
-* Be careful about unchecking the
-  :guilabel:`Browsable to Network Clients` box. When this box is
-  checked (the default), other users will see the names of every share
-  that exists using Windows Explorer, but they will receive a
-  permissions denied error message if they try to access someone
-  else's share. If this box is unchecked, even the owner of the share
-  will not see it or be able to create a drive mapping for the share
-  in Windows Explorer. However, they can still access the share from
-  the command line. Unchecking this option provides limited security
-  and is not a substitute for proper permissions and password control.
+* When the :guilabel:`Browsable to Network Clients` box is checked (the 
+  default), the share will be visible in the server's browse list. In the 
+  context of the special [homes] share, unchecking this box will hide the 
+  [homes] share so that only the dynamically generated home share with the
+  authenticated user's name [%U] will be visibile (in contrast with [homes]
+  and [%U] both being visible. The presence of a share in the user's browse 
+  list does not indicate that the user has read or write permissions on the 
+  share. Users are still able to directly access and map shares that are not 
+  visible in the browse list by using the share's UNC path. Hence, this option
+  is of limited security utility.
 
 * If some files on a shared volume should be hidden and inaccessible
   to users, put a *veto files=* line in the
@@ -1133,13 +1133,7 @@ like Windows 7 will not be able to connect with NTLMv1 disabled.
 `Security guidance for NTLMv1 and LM network authentication
 <https://support.microsoft.com/en-us/help/2793313/security-guidance-for-ntlmv1-and-lm-network-authentication>`_
 has information about the security implications and ways to enable
-NTLMv2. If changing the client configuration is not possible, NTLMv1
-authentication can be enabled by adding this entry to
-:guilabel:`Auxiliary Parameters`:
-
-.. code-block:: none
-
-   ntlm auth = yes
+NTLMv2.
 
 
 :numref:`Table %s <avail_vfs_modules_tab>`


### PR DESCRIPTION
In addition to these, enabling NTLMv1 auth is now handled by an checkbox in the UI under Services->SMB. No need to add an aux parameter.