### PR TITLE
Various edits to the "encryption" header text

### DIFF
--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1290,11 +1290,10 @@ Managing Encrypted Volumes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 %brand% automatically generates a randomized **encryption key** 
-whenever a new encrypted volume is created. The data "at rest" (on disk)
-on an encrypted volume is **always encrypted**, but access to the decrypted
-data on a live (running) system can be customized for each volume.
+whenever a new encrypted volume is created. %brand% needs this key 
+to read and decrypt any data (or any other information) within the volume.
 
-By default, encryption keys will be stored locally within %brand*'s data 
+By default, encryption keys will be stored locally within %brand%'s data 
 files. They can also be downloaded as a safety measure, to allow
 decryption on a different system in the event of failure, or to allow
 the locally stored key to be deleted for extra security. Encryption keys
@@ -1311,12 +1310,15 @@ implications are:
   data. If a passphrase is set, this must **also** be provided before data 
   can be accessed (`two factor authentication <https://en.wikipedia.org/wiki/Multi-factor_authentication>`_).
 
-Decrypted data **cannot be accessed** (other than from *L2ARC*) when the
-disks are removed, the system is shut down, or (on a running system) when 
-the key is unavailable. If the key is protected with a passphrase, then 
-data cannot be decrypted without having both key and passphrase. 
-Decryption is per-volume not per-user, so when a volume is unlocked, data 
-will be decrypted for *any* user whose permissions allow them to access it.
+Data stored on an encrypted volume disk is **always encrypted**. Data to be 
+written to an encrypted volume is encrypted when written to the LOG disk (ZIL),
+but is **not** stored encrypted in L2ARC, if present. With the exception of L2ARC, 
+decrypted data **cannot be accessed** when the disks are removed, the system
+has been shut down, or (on a running system) when the volume is 'locked' and
+the key is unavailable. If the key is protected with a passphrase, then data
+cannot be decrypted without having both key and passphrase. Decryption is 
+per-volume not per-user, so when a volume is unlocked, data will be decrypted
+for *any* user whose permissions allow them to access it.
 
 .. note:: By design, `GELI <http://www.freebsd.org/cgi/man.cgi?query=geli>`_
    uses *two* randomized encryption keys for each disk. One is the key discussed
@@ -1325,13 +1327,13 @@ will be decrypted for *any* user whose permissions allow them to access it.
    a disk's master key due to disk corruption would be equivalent to any other
    disk failure, and in a redundant pool, other disks will contain accessible 
    copies of the uncorrupted data.
-   Therefore, while it is *possible* to separately backup any master keys, 
-   it is **not** usually considered necessary or useful to do so.
+   Therefore, while it is *possible* to separately back up any master keys, 
+   it is not usually considered necessary or useful to do so.
 
 
-.. _Additional controls for encrypted volumes:
+.. _Additional Controls for Encrypted Volumes:
 
-Additional controls for encrypted volumes
+Additional Controls for Encrypted Volumes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If the :guilabel:`Encryption` box is checked during the creation of a

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -212,9 +212,9 @@ the details when considering whether encryption is right for your
   on top of the encrypted devices. As data is written, it is automatically 
   encrypted, and as data is read, it is decrypted on the fly. 
 
-* Data in the ARC cache and the contents of RAM are **always unencrypted**, 
-  and Swap is **always encrypted** (even on unencrypted volumes). The 
-  LOG (ZIL) cache is **encrypted if it relates to an encrypted disk**.
+* Data in memory, including ARC, is **not** encrypted. ZFS data on disk,
+  including ZIL and SLOG, are encrypted if the underlying disks **are** 
+  encrypted. Swap data on disk is **always** encrypted.
 
 * This type of encryption is primarily targeted at users who store
   sensitive data and want to retain the ability to remove disks from
@@ -230,10 +230,8 @@ the details when considering whether encryption is right for your
   inaccessible. Always back up the key!
 
 * The encryption key is per ZFS volume (pool). Multiple pools each
-  have their own encryption key. 
-  
-* Technical details about how encryption keys are used, stored and managed
-  within %brand% can be found in
+  have their own encryption key. Technical details about how encryption
+  keys are used, stored and managed within %brand% can be found in
   `this forum post <https://forums.freenas.org/index.php?threads/recover-encryption-key.16593/#post-85497>`_.
 
 * There is no way to convert an existing, unencrypted volume. Instead,
@@ -246,8 +244,14 @@ the details when considering whether encryption is right for your
   the existing encrypted pool.
 
 * The impact of encryption upon performance can be negligible or 
-  significant, depending upon the number of disks, and the CPU's 
-  capabilities. See :ref:`Encryption performance`.
+  significant, depending upon 
+#ifdef freenas
+  the number of disks, and the CPU's capabilities. 
+#endif freenas
+#ifdef truenas
+  the number of disks. 
+#endif truenas
+  See :ref:`Encryption performance`.
 
 .. note:: The encryption facility used by %brand% is designed to
    protect against physical theft of the disks. It is not designed to
@@ -270,23 +274,33 @@ the key, the data on the disks is inaccessible. Refer to
 Encryption performance
 ^^^^^^^^^^^^^^^^^^^^^^
 
+#ifdef freenas
 If the processor supports the 
 `AES-NI <https://en.wikipedia.org/wiki/AES-NI#Supporting_CPUs>`_
 instruction set, there is very little, if any, degradation in
 performance when using encryption and only a few disks.
-Performance will suffer if the CPU does not support
-AES-NI or if no crypto hardware is installed.  Without hardware
-acceleration, there will be about a 20% performance decrease for a
-single disk. 
+Performance will suffer if the CPU does not support AES-NI or if 
+no crypto hardware is installed.  Without hardware acceleration,
+there will be about a 20% performance decrease for a single disk. 
 This `forum post <https://forums.freenas.org/index.php?threads/encryption-performance-benchmarks.12157/>`__
 compares the performance of various CPUs.
+#endif freenas
 
+#ifdef freenas
 Performance also depends upon the number of disks encrypted.
 The more drives in an encrypted volume, the more encryption and
 decryption overhead, and the greater the impact on performance. 
+**Encrypted volumes composed of more than eight drives can suffer 
+severe performance penalties, even with AES-NI encryption acceleration**.
+#endif freenas
+#ifdef truenas
+Performance depends upon the number of disks encrypted.
+The more drives in an encrypted volume, the more encryption and
+decryption overhead, and the greater the impact on performance. 
 **Encrypted volumes composed of more than eight
-drives can suffer severe performance penalties, even with AES-NI
-encryption acceleration**. If encryption is desired, please
+drives can suffer severe performance penalties**. 
+#endif truenas
+If encryption is desired, please
 benchmark such volumes before using them in production.
 
 .. _Manual Setup:

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1311,12 +1311,12 @@ implications are:
   data. If a passphrase is set, this must **also** be provided before data 
   can be accessed (`two factor authentication <https://en.wikipedia.org/wiki/Multi-factor_authentication>`_).
 
-Decrypted data **cannot be accessed** when the disks are removed, the system 
-is shut down, or (on a running system) when the key is unavailable. If the 
-key is protected with a passphrase, then data cannot be decrypted without 
-having both key and passphrase. Decryption is per-volume not per-user, so 
-when a volume is unlocked, data will be decrypted for *any* user whose 
-permissions allow them to access it.
+Decrypted data **cannot be accessed** (other than from *L2ARC*) when the
+disks are removed, the system is shut down, or (on a running system) when 
+the key is unavailable. If the key is protected with a passphrase, then 
+data cannot be decrypted without having both key and passphrase. 
+Decryption is per-volume not per-user, so when a volume is unlocked, data 
+will be decrypted for *any* user whose permissions allow them to access it.
 
 .. note:: By design, `GELI <http://www.freebsd.org/cgi/man.cgi?query=geli>`_
    uses *two* randomized encryption keys for each disk. One is the key discussed

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1318,12 +1318,12 @@ when a volume is unlocked, data will be decrypted for *any* user whose
 permissions allow them to access it.
 
 .. note:: By design, `GELI <http://www.freebsd.org/cgi/man.cgi?query=geli>`_
-   uses two randomized encryption keys for each disk. One is the key discussed
-   in this guide, the other is a "master" key stored on the disk itself, in a
-   strongly encrypted form, which the user never sees. Loss of a disk's master key
-   due to disk corruption would be equivalent to any other disk failure, and 
-   as with any failure, other disks in the pool will contain accessible copies of 
-   the uncorrupted data. 
+   uses *two* randomized encryption keys for each disk. One is the key discussed
+   in this guide. The other, called the disk's "master key", is stored on the
+   disk itself, in a strongly encrypted form which the user never sees. Loss of 
+   a disk's master key due to disk corruption would be equivalent to any other
+   disk failure, and in a redundant pool, other disks will contain accessible 
+   copies of the uncorrupted data.
    Therefore, while it is *possible* to separately backup any master keys, 
    it is **not** considered necessary or useful to do so.
 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -212,9 +212,9 @@ the details when considering whether encryption is right for your
   on top of the encrypted devices. As data is written, it is automatically 
   encrypted, and as data is read, it is decrypted on the fly. 
 
-* Data in the ARC cache and the contents of RAM are always unencrypted, and 
-  Swap is always **encrypted** (even on unencrypted volumes). Data in the 
-  LOG (ZIL) cache is encrypted when it relates to an encrypted disk.
+* Data in the ARC cache and the contents of RAM are **always unencrypted**, 
+  and Swap is **always encrypted** (even on unencrypted volumes). The 
+  LOG (ZIL) cache is **encrypted if it relates to an encrypted disk**.
 
 * This type of encryption is primarily targeted at users who store
   sensitive data and want to retain the ability to remove disks from

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -230,8 +230,8 @@ the details when considering whether encryption is right for your
   inaccessible. Always back up the key!
 
 * The encryption key is per ZFS volume (pool). Multiple pools each
-  have their own encryption key.
-
+  have their own encryption key. 
+  
 * Technical details about how encryption keys are used, stored and managed
   within %brand% can be found in
   `this forum post <https://forums.freenas.org/index.php?threads/recover-encryption-key.16593/#post-85497>`_.
@@ -1316,6 +1316,17 @@ key is protected with a passphrase, then data cannot be decrypted without
 having both key and passphrase. Decryption is per-volume not per-user, so 
 when a volume is unlocked, data will be decrypted for *any* user whose 
 permissions allow them to access it.
+
+.. note:: By design, `GELI <http://www.freebsd.org/cgi/man.cgi?query=geli>`_
+   uses two randomized encryption keys for each disk. One is the key discussed
+   in this guide, the other is a "master" key stored on the disk itself, in a
+   strongly encrypted form, which the user never sees. Loss of a disk's master key
+   due to disk corruption would be equivalent to any other disk failure, and 
+   as with any failure, other disks in the pool will contain accessible copies of 
+   the uncorrupted data. 
+   Therefore, while it is *possible* to separately backup any master keys, 
+   it is **not** considered necessary or useful to do so.
+
 
 .. _Additional controls for encrypted volumes:
 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1289,6 +1289,39 @@ changed, and destroying a zvol requires confirmation.
 Managing Encrypted Volumes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+%brand% automatically generates a randomized **encryption key** 
+whenever a new encrypted volume is created. The data "at rest" (on disk)
+on an encrypted volume is **always encrypted**, but access to the decrypted
+data on a live (running) system can be customized for each volume.
+
+By default, encryption keys will be stored locally within %brand*'s data 
+files. They can also be downloaded as a safety measure, to allow
+decryption on a different system in the event of failure, or to allow
+the locally stored key to be deleted for extra security. Encryption keys
+can also be optionally protected with a **passphrase**:
+
+* *Key stored locally, no passphrase* - data is automatically decrypted 
+  and always accessible when system running. (Protects "data at rest" only.)
+
+* *Key stored locally, with passphrase* - user must provide passphrase
+  before anyone can access data.
+
+* *Key not stored locally* - user must provide key before anyone can access
+  data. If a passphrase is set, this must **also** be provided before data 
+  can be accessed (`two factor authentication <https://en.wikipedia.org/wiki/Multi-factor_authentication>`_).
+
+Decrypted data **cannot be accessed** when the disks are removed, the system 
+is shut down, or (on a running system) when the key is unavailable. If the 
+key is protected with a passphrase, then data cannot be decrypted without 
+having both key and passphrase. Decryption is per-volume not per-user, so 
+when a volume is unlocked, data will be decrypted for *any* user whose 
+permissions allow them to access it.
+
+.. _Additional controls for encrypted volumes:
+
+Additional controls for encrypted volumes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 If the :guilabel:`Encryption` box is checked during the creation of a
 pool, additional buttons appear in the entry for the volume in
 :menuselection:`Storage --> Volumes`.

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -227,21 +227,9 @@ the details when considering whether encryption is right for your
 * The encryption key is per ZFS volume (pool). Multiple pools each
   have their own encryption key.
 
-#ifdef freenas
-* If the system has a lot of disks, performance will suffer if the CPU
-  does not support
-  `AES-NI <https://en.wikipedia.org/wiki/AES-NI#Supporting_CPUs>`_
-  or if no crypto hardware is installed. Without hardware
-  acceleration, there will be about a 20% performance decrease for a
-  single disk. Performance degradation increases with more disks. As
-  data is written, it is automatically encrypted. As data is read, it
-  is decrypted on the fly. If the processor supports the AES-NI
-  instruction set, there is very little, if any, degradation in
-  performance when using encryption. This
-  `forum post
-  <https://forums.freenas.org/index.php?threads/encryption-performance-benchmarks.12157/>`__
-  compares the performance of various CPUs.
-#endif freenas
+* Technical details about how encryption keys are used, stored and managed
+  within %brand% can be found in
+  `this forum post <https://forums.freenas.org/index.php?threads/recover-encryption-key.16593/#post-85497>`_.
 
 * Data in the ARC cache and the contents of RAM are unencrypted.
 
@@ -256,12 +244,9 @@ the details when considering whether encryption is right for your
   Volume Manager automatically encrypts the new vdev being added to
   the existing encrypted pool.
 
-* The more drives in an encrypted volume, the more encryption and
-  decryption overhead. **Encrypted volumes composed of more than eight
-  drives can suffer severe performance penalties, even with AES-NI
-  encryption acceleration**. If encryption is desired, please
-  benchmark such volumes before using them in production.
-
+* The impact of encryption upon performance can be negligible or 
+  significant, depending upon the number of disks, and the CPU's 
+  capabilities. See :ref:`Encryption performance`.
 
 .. note:: The encryption facility used by %brand% is designed to
    protect against physical theft of the disks. It is not designed to
@@ -279,6 +264,32 @@ A pop-up message shows a reminder that
 the key, the data on the disks is inaccessible. Refer to
 :ref:`Managing Encrypted Volumes` for instructions.
 
+.. _Encryption performance:
+
+Encryption performance
+^^^^^^^^^^^^^^^^^^^^^^
+
+#ifdef freenas
+* If the system has a lot of disks, performance will suffer if the CPU
+  does not support
+  `AES-NI <https://en.wikipedia.org/wiki/AES-NI#Supporting_CPUs>`_
+  or if no crypto hardware is installed. Without hardware
+  acceleration, there will be about a 20% performance decrease for a
+  single disk. Performance degradation increases with more disks. As
+  data is written, it is automatically encrypted. As data is read, it
+  is decrypted on the fly. If the processor supports the AES-NI
+  instruction set, there is very little, if any, degradation in
+  performance when using encryption. This
+  `forum post
+  <https://forums.freenas.org/index.php?threads/encryption-performance-benchmarks.12157/>`__
+  compares the performance of various CPUs.
+#endif freenas
+
+* The more drives in an encrypted volume, the more encryption and
+  decryption overhead. **Encrypted volumes composed of more than eight
+  drives can suffer severe performance penalties, even with AES-NI
+  encryption acceleration**. If encryption is desired, please
+  benchmark such volumes before using them in production.
 
 .. _Manual Setup:
 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -213,7 +213,8 @@ the details when considering whether encryption is right for your
   encrypted, and as data is read, it is decrypted on the fly. 
 
 * Data in the ARC cache and the contents of RAM are always unencrypted, and 
-  Swap is always encrypted (even on unencrypted volumes).
+  Swap is always **encrypted** (even on unencrypted volumes). Data in the 
+  LOG (ZIL) cache is encrypted when it relates to an encrypted disk.
 
 * This type of encryption is primarily targeted at users who store
   sensitive data and want to retain the ability to remove disks from

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1326,7 +1326,7 @@ will be decrypted for *any* user whose permissions allow them to access it.
    disk failure, and in a redundant pool, other disks will contain accessible 
    copies of the uncorrupted data.
    Therefore, while it is *possible* to separately backup any master keys, 
-   it is **not** considered necessary or useful to do so.
+   it is **not** usually considered necessary or useful to do so.
 
 
 .. _Additional controls for encrypted volumes:

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1298,7 +1298,8 @@ By default, encryption keys will be stored locally within %brand*'s data
 files. They can also be downloaded as a safety measure, to allow
 decryption on a different system in the event of failure, or to allow
 the locally stored key to be deleted for extra security. Encryption keys
-can also be optionally protected with a **passphrase**:
+can also be optionally protected with a **passphrase**. The security 
+implications are:
 
 * *Key stored locally, no passphrase* - data is automatically decrypted 
   and always accessible when system running. (Protects "data at rest" only.)

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -209,7 +209,11 @@ the details when considering whether encryption is right for your
 
 * This is full disk encryption and **not** per-filesystem encryption.
   The underlying drives are first encrypted, then the pool is created
-  on top of the encrypted devices.
+  on top of the encrypted devices. As data is written, it is automatically 
+  encrypted, and as data is read, it is decrypted on the fly. 
+
+* Data in the ARC cache and the contents of RAM are always unencrypted, and 
+  Swap is always encrypted (even on unencrypted volumes).
 
 * This type of encryption is primarily targeted at users who store
   sensitive data and want to retain the ability to remove disks from
@@ -230,10 +234,6 @@ the details when considering whether encryption is right for your
 * Technical details about how encryption keys are used, stored and managed
   within %brand% can be found in
   `this forum post <https://forums.freenas.org/index.php?threads/recover-encryption-key.16593/#post-85497>`_.
-
-* Data in the ARC cache and the contents of RAM are unencrypted.
-
-* Swap is always encrypted, even on unencrypted volumes.
 
 * There is no way to convert an existing, unencrypted volume. Instead,
   the data must be backed up, the existing pool destroyed, a new
@@ -269,27 +269,24 @@ the key, the data on the disks is inaccessible. Refer to
 Encryption performance
 ^^^^^^^^^^^^^^^^^^^^^^
 
-#ifdef freenas
-* If the system has a lot of disks, performance will suffer if the CPU
-  does not support
-  `AES-NI <https://en.wikipedia.org/wiki/AES-NI#Supporting_CPUs>`_
-  or if no crypto hardware is installed. Without hardware
-  acceleration, there will be about a 20% performance decrease for a
-  single disk. Performance degradation increases with more disks. As
-  data is written, it is automatically encrypted. As data is read, it
-  is decrypted on the fly. If the processor supports the AES-NI
-  instruction set, there is very little, if any, degradation in
-  performance when using encryption. This
-  `forum post
-  <https://forums.freenas.org/index.php?threads/encryption-performance-benchmarks.12157/>`__
-  compares the performance of various CPUs.
-#endif freenas
+If the processor supports the 
+`AES-NI <https://en.wikipedia.org/wiki/AES-NI#Supporting_CPUs>`_
+instruction set, there is very little, if any, degradation in
+performance when using encryption and only a few disks.
+Performance will suffer if the CPU does not support
+AES-NI or if no crypto hardware is installed.  Without hardware
+acceleration, there will be about a 20% performance decrease for a
+single disk. 
+This `forum post <https://forums.freenas.org/index.php?threads/encryption-performance-benchmarks.12157/>`__
+compares the performance of various CPUs.
 
-* The more drives in an encrypted volume, the more encryption and
-  decryption overhead. **Encrypted volumes composed of more than eight
-  drives can suffer severe performance penalties, even with AES-NI
-  encryption acceleration**. If encryption is desired, please
-  benchmark such volumes before using them in production.
+Performance also depends upon the number of disks encrypted.
+The more drives in an encrypted volume, the more encryption and
+decryption overhead, and the greater the impact on performance. 
+**Encrypted volumes composed of more than eight
+drives can suffer severe performance penalties, even with AES-NI
+encryption acceleration**. If encryption is desired, please
+benchmark such volumes before using them in production.
 
 .. _Manual Setup:
 


### PR DESCRIPTION
1) Link to a more exact description about GELI key management.

People using encryption (and managing its various keys) are likely to be the kind of people who will want exact details how keys are stored and managed. While they could Google GELI, that won't explain how %brand% uses and stores them, and is a lot to read through. However there's a nice and concise forum post which summarises it nicely and worth linking to for that info.....

2) Move "encryption performance" to its own small heading below the bullet list

Performance is always a question/concern with encryption. This keeps the main bullet list short and "to the point", and pulls the 1 or 2 bullets on performance to below the list, which (to me) flows much better.

3) Merge "encrypted on write" and "decrypted on fly during read" to a previous bullet where they fit nicely

4) Remove an "#ifdef freenas" - this seems to apply universally not just to specific %brand%s as it's generic to any hw and GELI use. If incorrect please edit to fix!

5) Cleaner separation between CPU AES-NI impact and disk count impact, and reduce redundant wording (we mention "multiple disk degradation" twice and blur it with AES-NI impact)

6) Mention whether LOG (ZIL) is encrypted or not, since we already mention everything else (RAM, L2ARC and SWAP).

7) The section on "managing encryption" describes the existence and controls over keys and passphrases, but doesn't tell the user what each is, and what they do. Fairly crucial information to be clear about before we tell the user about buttons that are shown to manage them :)

8) Mention (in a note) that it's rarely useful to back up a disk's master keys - because this is a very obvious and usual concern/question with full disk encryption systems, and the answer isn't very obvious. No need for users to be worried if considering use of encryption.