### PR TITLE
Rsync service + tasks

### DIFF
--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1061,12 +1061,13 @@ that has greater access or privileges than the transfer requires.
 Particularly, **do not use the root account for Rsync** without carefully
 considering security imlications. 
 
-Rsyncd also supports "forced commands" - configurations where a remote
+Rsyncd can also be configured to create "forced commands", in which a remote
 user can only control some pre-defined session parameters (or none of them), 
-all other session properties being defined within the rsyncd configuration
-of the %brand% server. These are outside the scope of this Guide but allow
-partially or totally restricted use of Rsync. They are covered in 
-`rsyncd.conf(5) <http://www.samba.org/ftp/rsync/rsyncd.conf.html>`_.
+all other session properties being controlled within the %brand% server
+configuration, using SSH options such as "AuthorizedKeys" and "ForceCommand".
+These are outside the scope of this Guide but allow partially or totally 
+restricted use of Rsync. They are covered in 
+`sshd_config(5) <https://www.freebsd.org/cgi/man.cgi?sshd_config(5)>`_.
 
 .. _Managing Rsync:
 

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1046,21 +1046,6 @@ previously been sent, Rsync reduces the amount of data sent over the
 network by sending only the differences between the source and destination 
 files. 
 
-In %brand% terminology, the execution of an RSync activity by the %brand% 
-server is controlled by an "Rsync task".  To synchronize data between two 
-%brand% systems, create the rsync task on the rsync client.
-
-Depending upon how rsync is to be used, Rsync configuration may require 
-configuration of any or all of the rsyncd daemon, rsync modules, and rsync 
-tasks. Global parameters for the rsyncd daemon are specified in the rsyncd 
-configuration screen which is accessed from :menuselection:`Services --> 
-Rsync --> Configure Rsyncd`.  Configuration settings to be used for 
-specific kinds of Rsync tasks, known as "Rsync modules", can be defined 
-and saved individually in the rsyncd modules screen, which is accessed 
-from :menuselection:`Services --> Rsync --> Rsync Modules --> Add Rsync 
-Module`. Rsync tasks to be executed can be defined at   
-:menuselection:`Tasks --> Rsync Tasks`.
-
 %brand% supports two modes of rsync operation:
 
 * **rsync module mode:** exports a directory tree, and its configured
@@ -1077,6 +1062,19 @@ Module`. Rsync tasks to be executed can be defined at
 :menuselection:`Services --> Rsync`
 is used to configure an rsync server when using rsync module mode. Refer
 to :ref:`Rsync Module Mode` for a configuration example.
+
+Depending upon how rsync is to be used, Rsync configuration may require 
+configuration of any or all of the rsyncd daemon, rsync modules, and rsync 
+tasks. Global parameters for the rsyncd daemon are specified in the rsyncd 
+configuration screen which is accessed from :menuselection:`Services --> 
+Rsync --> Configure Rsyncd`.  Configuration settings to be used for 
+specific kinds of Rsync tasks, known as "Rsync modules", can be defined 
+and saved individually in the rsyncd modules screen, which is accessed 
+from :menuselection:`Services --> Rsync --> Rsync Modules --> Add Rsync 
+Module`. Execution of RSync activities by the %brand% 
+server (called an "Rsync task") can be defined at   
+:menuselection:`Tasks --> Rsync Tasks`. To synchronize data between two 
+%brand% systems, create the rsync task on the rsync client.
 
 This section describes the configurable options for the
 :command:`rsyncd` service and rsync modules.

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1027,7 +1027,7 @@ Rsync
 -----
 
 `Rsync <http://www.samba.org/ftp/rsync/rsync.html>`_
-is a versatile and widely used utility that copies specified data
+is a versatile and popular utility that copies specified data
 from one system to another over a network. It is widely used for 
 directory/file synchronization, backup and restore, and compatible 
 with many popular systems, and can be used for backups, mirroring 

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1172,8 +1172,8 @@ summarizes the options that can be configured for the rsync daemon:
 Rsync Modules
 ~~~~~~~~~~~~~
 
-An **rsync module** contains parameters that define a specific type of 
-Rsync task. A module should be created for each task that will run in 
+An **rsync module** contains parameters that are used by a specific Rsync task, or set of 
+Rsync actions. A module should be created for each task that will run in 
 **module mode**, and given a unique name. The same module name is 
 also used on the remote system, so that Rsync on both the %brand% 
 server and the remote system can identify the module being executed.  

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1111,7 +1111,7 @@ the Internet, then **use of Rsync over SSH is highly recommended**.
 It is also **highly recommended** not to use an account for the transfer, 
 that has greater access or privileges than the transfer requires.
 Particularly, **do not use the root account for Rsync** without carefully
-considering security imlications. 
+considering security implications. 
 
 It is possible to create a partially or totally restricted Rsync activity
 (whether or not a privileged account is used) by using "forced commands". This 

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1046,6 +1046,17 @@ previously been sent, Rsync reduces the amount of data sent over the
 network by sending only the differences between the source and destination 
 files. 
 
+.. warning:: Rsync does not by default use secure or encrypted network
+   protocols such as TLS or SSH for data transfer. If security in transit 
+   is required, either within a local network or over a network such as 
+   the Internet, then **use of Rsync over SSH is highly recommended**.
+
+   It is also **highly recommended** not to use an account for the transfer, 
+   that has greater access or privileges than the transfer requires.
+   Particularly, **do not use the root account for Rsync** without carefully
+   considering security imlications.
+
+
 .. _Managing Rsync:
 
 Managing Rsync

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1061,12 +1061,13 @@ that has greater access or privileges than the transfer requires.
 Particularly, **do not use the root account for Rsync** without carefully
 considering security imlications. 
 
-Rsyncd can also be configured to create "forced commands", in which a remote
-user can only control some pre-defined session parameters (or none of them), 
-all other session properties being controlled within the %brand% server
-configuration, using SSH options such as "AuthorizedKeys" and "ForceCommand".
-These are outside the scope of this Guide but allow partially or totally 
-restricted use of Rsync. They are covered in 
+It is also possible to create a partially or totally restricted Rsync activity
+(whether or not a privileged account is used) by using "forced commands". This 
+feature of the %brand% SSH service allows a remote user only limited (or no) 
+control over the actions within an Rsync session, with all other 
+session activity defined in the %brand% server's configuration. 
+This technique is outside the scope of this guide but can be found by looking for
+options such as  "AuthorizedKeys" and "ForceCommand" in  
 `sshd_config(5) <https://www.freebsd.org/cgi/man.cgi?sshd_config(5)>`_.
 
 .. _Managing Rsync:

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1113,9 +1113,9 @@ that has greater access or privileges than the transfer requires.
 Particularly, **do not use the root account for Rsync** without carefully
 considering security imlications. 
 
-It is also possible to create a partially or totally restricted Rsync activity
+It is possible to create a partially or totally restricted Rsync activity
 (whether or not a privileged account is used) by using "forced commands". This 
-feature of the %brand% SSH service allows a remote user only limited (or no) 
+feature of the %brand% :ref:`SSH` service allows a remote user only limited (or no) 
 control over the actions within an Rsync session, with all other 
 session activity defined in the %brand% server's configuration. 
 This technique is outside the scope of this guide but can be found by looking for

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1046,16 +1046,27 @@ previously been sent, Rsync reduces the amount of data sent over the
 network by sending only the differences between the source and destination 
 files. 
 
-.. warning:: Rsync does not by default use secure or encrypted network
-   protocols such as TLS or SSH for data transfer. If security in transit 
-   is required, either within a local network or over a network such as 
-   the Internet, then **use of Rsync over SSH is highly recommended**.
+.. _Rsync Security:
 
-   It is also **highly recommended** not to use an account for the transfer, 
-   that has greater access or privileges than the transfer requires.
-   Particularly, **do not use the root account for Rsync** without carefully
-   considering security imlications.
+Rsync Security
+^^^^^^^^^^^^^^
 
+Rsync does not by default use secure or encrypted network
+protocols such as TLS or SSH for data transfer. If security in transit 
+is required, either within a local network or over a network such as 
+the Internet, then **use of Rsync over SSH is highly recommended**.
+
+It is also **highly recommended** not to use an account for the transfer, 
+that has greater access or privileges than the transfer requires.
+Particularly, **do not use the root account for Rsync** without carefully
+considering security imlications. 
+
+Rsyncd also supports "forced commands" - configurations where a remote
+user can only control some pre-defined session parameters (or none of them), 
+all other session properties being defined within the rsyncd configuration
+of the %brand% server. These are outside the scope of this Guide but allow
+partially or totally restricted use of Rsync. They are covered in 
+`rsyncd.conf(5) <http://www.samba.org/ftp/rsync/rsyncd.conf.html>`_.
 
 .. _Managing Rsync:
 

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1046,47 +1046,6 @@ previously been sent, Rsync reduces the amount of data sent over the
 network by sending only the differences between the source and destination 
 files. 
 
-.. _Rsync Security:
-
-Rsync Security
-^^^^^^^^^^^^^^
-
-Rsync does not by default use secure or encrypted network
-protocols such as TLS or SSH for data transfer. If security in transit 
-is required, either within a local network or over a network such as 
-the Internet, then **use of Rsync over SSH is highly recommended**.
-
-It is also **highly recommended** not to use an account for the transfer, 
-that has greater access or privileges than the transfer requires.
-Particularly, **do not use the root account for Rsync** without carefully
-considering security imlications. 
-
-It is also possible to create a partially or totally restricted Rsync activity
-(whether or not a privileged account is used) by using "forced commands". This 
-feature of the %brand% SSH service allows a remote user only limited (or no) 
-control over the actions within an Rsync session, with all other 
-session activity defined in the %brand% server's configuration. 
-This technique is outside the scope of this guide but can be found by looking for
-options such as  "AuthorizedKeys" and "ForceCommand" in  
-`sshd_config(5) <https://www.freebsd.org/cgi/man.cgi?sshd_config(5)>`_.
-
-.. _Managing Rsync:
-
-Managing Rsync
-~~~~~~~~~~~~~~
-
-Rsync is most effective when only a relatively small amount of the
-data has changed. There are also
-`some limitations when using Rsync with Windows files
-<https://forums.freenas.org/index.php?threads/impaired-rsync-permissions-support-for-windows-datasets.43973/>`_.
-For large amounts of data, data that has many changes from the
-previous copy, or Windows files, :ref:`Replication Tasks` are often
-the faster and better solution.
-
-Rsync is single-threaded, so gains little from multiple processor
-cores. To see whether rsync is currently running, use
-:samp:`pgrep rsync` from the :ref:`Shell`.
-
 In %brand% terminology, the execution of an RSync activity by the %brand% 
 server is controlled by an "Rsync task".  To synchronize data between two 
 %brand% systems, create the rsync task on the rsync client.
@@ -1121,6 +1080,49 @@ to :ref:`Rsync Module Mode` for a configuration example.
 
 This section describes the configurable options for the
 :command:`rsyncd` service and rsync modules.
+
+
+.. _Rsync Efficiency:
+
+Rsync Efficiency
+~~~~~~~~~~~~~~~~
+
+Rsync is most effective when only a relatively small amount of the
+data has changed. There are also
+`some limitations when using Rsync with Windows files
+<https://forums.freenas.org/index.php?threads/impaired-rsync-permissions-support-for-windows-datasets.43973/>`_.
+For large amounts of data, data that has many changes from the
+previous copy, or Windows files, :ref:`Replication Tasks` are often
+the faster and better solution.
+
+Rsync is single-threaded, so gains little from multiple processor
+cores. To see whether rsync is currently running, use
+:samp:`pgrep rsync` from the :ref:`Shell`.
+
+
+.. _Rsync Security:
+
+Rsync Security
+~~~~~~~~~~~~~~
+
+Rsync does not by default use secure or encrypted network
+protocols such as TLS or SSH for data transfer. If security in transit 
+is required, either within a local network or over a network such as 
+the Internet, then **use of Rsync over SSH is highly recommended**.
+
+It is also **highly recommended** not to use an account for the transfer, 
+that has greater access or privileges than the transfer requires.
+Particularly, **do not use the root account for Rsync** without carefully
+considering security imlications. 
+
+It is also possible to create a partially or totally restricted Rsync activity
+(whether or not a privileged account is used) by using "forced commands". This 
+feature of the %brand% SSH service allows a remote user only limited (or no) 
+control over the actions within an Rsync session, with all other 
+session activity defined in the %brand% server's configuration. 
+This technique is outside the scope of this guide but can be found by looking for
+options such as  "AuthorizedKeys" and "ForceCommand" in  
+`sshd_config(5) <https://www.freebsd.org/cgi/man.cgi?sshd_config(5)>`_.
 
 
 .. _Configure Rsyncd:

--- a/userguide/tasks.rst
+++ b/userguide/tasks.rst
@@ -396,52 +396,16 @@ Rsync Tasks
 -----------
 
 `Rsync <http://www.samba.org/ftp/rsync/rsync.html>`_
-is a utility that copies specified data from one system to another
-over a network. Once the initial data is copied, rsync reduces the
-amount of data sent over the network by sending only the differences
-between the source and destination files. Rsync can be used for
-backups, mirroring data on multiple systems, or for copying files
-between systems.
+is a versatile and widely used utility that copies specified data
+from one system to another over a network. It is widely used for 
+directory/file synchronization, backup and restore, and compatible 
+with many popular systems, and can be used for backups, mirroring 
+data on multiple systems, or for copying files between systems.
 
-Rsync is most effective when only a relatively small amount of the
-data has changed. There are also
-`some limitations when using Rsync with Windows files
-<https://forums.freenas.org/index.php?threads/impaired-rsync-permissions-support-for-windows-datasets.43973/>`_.
-For large amounts of data, data that has many changes from the
-previous copy, or Windows files, :ref:`Replication Tasks` are often
-the faster and better solution.
-
-Rsync is single-threaded, so gains little from multiple processor
-cores. To see whether rsync is currently running, use
-:samp:`pgrep rsync` from the :ref:`Shell`.
-
-Both ends of an rsync connection must be configured:
-
-* **the rsync server:** this system pulls (receives) the data. This
-  system is referred to as *PULL* in the configuration examples.
-
-* **the rsync client:** this system pushes (sends) the data. This
-  system is referred to as *PUSH* in the configuration examples.
-
-%brand% can be configured as either an rsync client or an rsync
-server. The opposite end of the connection can be another %brand%
-system or any other system running rsync. In %brand% terminology, an
-rsync task defines which data is synchronized between the two systems.
-To synchronize data between two %brand% systems, create the rsync task
-on the rsync client.
-
-%brand% supports two modes of rsync operation:
-
-* **rsync module mode:** exports a directory tree, and its configured
-  settings, as a symbolic name over an unencrypted connection. This
-  mode requires that at least one module be defined on the rsync
-  server. It can be defined in the %brand% GUI under
-  :menuselection:`Services --> Rsync --> Rsync Modules`.
-  In other operating systems, the module is defined in
-  `rsyncd.conf(5) <http://www.samba.org/ftp/rsync/rsyncd.conf.html>`_.
-
-* **rsync over SSH:** synchronizes over an encrypted connection.
-  Requires the configuration of SSH user and host public keys.
+%brand% supports two modes of rsync operation: **rsync module mode** 
+and **rsync over SSH**. Details of %brand%'s Rsync services and an
+explanation of Rsync terminology used in this section, can be 
+found on the page for the :ref:`Rsync service`.
 
 This section summarizes the options when creating an Rsync Task. It
 then provides a configuration example between two %brand% systems for


### PR DESCRIPTION
See https://redmine.ixsystems.com/issues/21374 . 

1) A lot of the detail under rsync tasks was really more about rsync background, and overlapped with the service page.  So I've collected all the rsync background, basics and terminology at "Rsync service" for user ease, which simplifies the "tasks" page considerably.

2) A lot of the text on Rsync wasn't helpful at all. (See redmine link above). I've tried to tune it a little without adding much or getting into detailed config, so a user gets a better idea of this valuable service and the terminology used by *NAS.

3) The guide doesn't cover two rather crucial "need to know"s about Rsync - It doesn't encrypt data, so use some kind of secure transport (SSH) across insecure networks or internet if this matters, and use a minimally privileged account for the task - and especially not your root user. I don't know to what extent middleware will check someone using an overprivileged account (even if not root), but both of these warnings should probably be explicitly stated, however briefly.

I'm not 100% sure the correct/preferred terminology so this is bound to need some tidying up, and perhaps some minor fixes if I've missed anything. Please be gentle! 

But overall, this PR should help users on this valuable service without overstraying into additional rsyncd.conf material.

