### PR TITLE
Clarify 88 byte limit with examples

### DIFF
--- a/userguide/snippets/pathlengths.rst
+++ b/userguide/snippets/pathlengths.rst
@@ -43,29 +43,27 @@ can also reduce the length of these limits by one or more bytes.
    |                     |                | being created.                                                         |
    +---------------------+----------------+------------------------------------------------------------------------+
 
-Care is needed with regard to ZFS snapshots. **If the mounted path length for a snapshot exceeds 88 characters, 
-then the snapshot and any contained data will be safe but inaccessible until the mounted path length of the snapshot has been shortened**. Typically this is done by **renaming the pool, dataset or snapshot** to shorter names, so that the path length is
-below the 88 byte limit. ZFS will perform any necessary unmount or remount of the file system if a pool, dataset or 
-snapshot are renamed. If the **mountpoint** is to be renamed instead, then any object mounted on the mountpoint must
-be manually unmounted using the :command:`CLI` before renaming, and can be remounted after. 
-:command:`umount /mnt/mymountpoint` can be used to unmount a file system.
+Care is needed with regard to ZFS snapshots. **If the mounted path length for a snapshot exceeds 88 characters, then 
+the snapshot and any contained data will be safe but inaccessible until the mounted path length of the snapshot has 
+been shortened**.  The 88 character limit affects automatic and manual snapshot mounts slightly differently:
 
-As well as snapshots being manually mounted from the command line, ZFS automatically mounts snapshots within 
-hidden :file:`/.zfs/snapshot/` directories, whenever an attempt is made to access their contents. The 88 byte limit 
-affects both types of mount.
+- **Automatic mount:** ZFS temporarily mounts snapshots whenever a user attempts to view or search the files it contains. 
+The mountpoint used will be a hidden :file:`.zfs/snapshot/{name}` directory within the same ZFS dataset. For 
+example, the snapshot :file:`mypool/dataset/snap1@snap2` is mounted at :file:`/mnt/mypool/dataset/.zfs/snapshot/snap2/`. 
+If the length of this path exceeds 88 characters then the snapshot will not be automatically mounted by ZFS and the 
+snapshot contents will not be visible or searchable. This can be resolved either by renaming the ZFS pool or dataset
+containing the snapshot to shorter names (:file:`mypool` or :file:`dataset`), or by shortening the second part of the 
+snapshot name (:file:`snap2`), so that the total mounted path length does not exceed 88 characters.  ZFS will 
+automatically perform any necessary unmount or remount of the file system. After renaming, the contents will be visible 
+and searchable again.
 
-Examples:
+- **Manual mount:** If the same snapshot as above is to be mounted manually from the :ref:`CLI`:, using
+:command:`mount -t zfs mypool/dataset/snap1@snap2 /mnt/mymountpoint` then the path :file:`/mnt/mountpoint/` must not
+exceed 88 characters, but the length of the snapshot name is irrelevant. When renaming a manual mountpoint, any object
+mounted on the mountpoint must be manually unmounted (using the :command:`umount` command in the :command:`CLI`) before
+renaming the mountpoint, and can be remounted afterwards.
 
-- **Automatic mount:** ZFS temporarily mounts snapshots whenever a user attempts to view or search the files it contains. The 
-mountpoint used will be a hidden :file:`.zfs/snapshot/snapshotname` directory within the same ZFS dataset. For example, the 
-snapshot :file:`mypool/dataset/snap1@snap2` is mounted at :file:`/mnt/mypool/dataset/.zfs/snapshot/snap2/`. If this exceeds 
-88 characters then the snapshot will not be automatically mounted by ZFS and the snapshot contents will not be visible or 
-searchable. This can be resolved either by renaming the ZFS pool or dataset containing the snapshot to shorter names (:file:`mypool`
-or :file:`dataset`) or by shortening the second part of the snapshot name (:file:`snap2`), so that the total length
-does not exceed 88 characters. 
+.. note:: A snapshot that cannot be mounted automatically by ZFS, can still be mounted manually from the :ref:`CLI`using 
+a shorter mountpoint path, making it possible to mount and access snapshots that cannot be accessed automatically by 
+the GUI or with features such as "File History" or "Versions".
 
-- **Manual mount:** If the same snapshot is to be mounted manually from the :ref:`CLI`:, using 
-:command:`mount -t zfs mypool/dataset/snap1@snap2 /mnt/mymountpoint` then the path :file:`/mnt/mountpoint/` 
-must not exceed 88 characters. 
-
-.. note:: A snapshot that cannot be mounted automatically by ZFS, can still be mounted manually from the :ref:`CLI` using a shorter mountpoint path, making it possible to mount snapshots that cannot be mounted automatically by the GUI.

--- a/userguide/snippets/pathlengths.rst
+++ b/userguide/snippets/pathlengths.rst
@@ -47,23 +47,22 @@ Care is needed with regard to ZFS snapshots. **If the mounted path length for a 
 the snapshot and any contained data will be safe but inaccessible until the mounted path length of the snapshot has 
 been shortened**.  The 88 character limit affects automatic and manual snapshot mounts slightly differently:
 
-- **Automatic mount:** ZFS temporarily mounts snapshots whenever a user attempts to view or search the files it contains. 
-The mountpoint used will be a hidden :file:`.zfs/snapshot/{name}` directory within the same ZFS dataset. For 
+- **Automatic mount:** ZFS temporarily mounts snapshots whenever a user attempts to view or search the files within the 
+snapshot. The mountpoint used will be a hidden :file:`.zfs/snapshot/{name}` directory within the same ZFS dataset. For 
 example, the snapshot :file:`mypool/dataset/snap1@snap2` is mounted at :file:`/mnt/mypool/dataset/.zfs/snapshot/snap2/`. 
 If the length of this path exceeds 88 characters then the snapshot will not be automatically mounted by ZFS and the 
-snapshot contents will not be visible or searchable. This can be resolved either by renaming the ZFS pool or dataset
+snapshot contents will not be visible or searchable. This can be resolved by renaming the ZFS pool or dataset
 containing the snapshot to shorter names (:file:`mypool` or :file:`dataset`), or by shortening the second part of the 
 snapshot name (:file:`snap2`), so that the total mounted path length does not exceed 88 characters.  ZFS will 
-automatically perform any necessary unmount or remount of the file system. After renaming, the contents will be visible 
-and searchable again.
+automatically perform any necessary unmount or remount of the file system as part of the rename operation. After 
+renaming, the snapshot's contents will be visible and searchable again.
 
 - **Manual mount:** If the same snapshot as above is to be mounted manually from the :ref:`CLI`:, using
 :command:`mount -t zfs mypool/dataset/snap1@snap2 /mnt/mymountpoint` then the path :file:`/mnt/mountpoint/` must not
-exceed 88 characters, but the length of the snapshot name is irrelevant. When renaming a manual mountpoint, any object
+exceed 88 characters, but the length of the snapshot name will be *irrelevant*. When renaming a manual mountpoint, any object
 mounted on the mountpoint must be manually unmounted (using the :command:`umount` command in the :command:`CLI`) before
 renaming the mountpoint, and can be remounted afterwards.
 
-.. note:: A snapshot that cannot be mounted automatically by ZFS, can still be mounted manually from the :ref:`CLI`using 
-a shorter mountpoint path, making it possible to mount and access snapshots that cannot be accessed automatically by 
-the GUI or with features such as "File History" or "Versions".
+.. note:: A snapshot that cannot be mounted automatically by ZFS, can still be mounted manually from the :ref:`CLI` using 
+a shorter mountpoint path. This makes it possible to mount and access snapshots that cannot be accessed automatically in other ways, such as from the GUI or from features such as "File History" or "Versions".
 

--- a/userguide/snippets/pathlengths.rst
+++ b/userguide/snippets/pathlengths.rst
@@ -44,17 +44,27 @@ can also reduce the length of these limits by one or more bytes.
    +---------------------+----------------+------------------------------------------------------------------------+
 
 Care is needed with regard to ZFS snapshots. **If the mounted path length for a snapshot exceeds 88 characters, 
-then the snapshot and its data will be safe but inaccessible until its mounted path length is reduced**. 
-Typically this is rectified by renaming (shortening) the dataset, snapshot, or mountpoint, so that the path length is
-below the 88 byte limit. Note that ZFS snapshots are automatically mounted on demand within hidden :file:`/.zfs/snapshot/`
-directories, and can also be manually mounted using the command line. The 88 byte limit affects both types of mount.
+then the snapshot and any contained data will be safe but inaccessible until the mounted path length of the snapshot has been shortened**. Typically this is done by renaming (shortening) the dataset or snapshot, so that the path length is
+below the 88 byte limit. ZFS will perform any necessary unmount or remount of the file system as part of the rename. 
+If the mountpoint is to be renamed, then any object mounted on the mountpoint must be unmounted before renaming, and
+can be remounted after. :command:`umount /mnt/mymountpoint` can be used to unmount a file system.
+
+ZFS automatically mounts snapshots within hidden :file:`/.zfs/snapshot/` directories, when an attempt is made to access 
+their contents. Snapshots can also be manually mounted (to any valid location) from the command line. The 88 byte limit 
+will affect both types of mount.
 
 Examples:
 
-- **Automatic mount:** Any time a user attempts to navigate to a snapshot, or search or access its contents, ZFS must temporarily mount the snapshot. Typically the snapshot :file:`mypool/dataset/snap1@snap2` will be mounted at the path
-:file:`/mnt/mypool/dataset/.zfs/snapshot/snap2/`, which must not exceed 88 characters. 
+- **Automatic mount:** ZFS temporarily mounts snapshots whenever a user attempts to view or search the files it contains. The 
+mountpoint used will be a hidden :file:`.zfs/snapshot/snapshotname` directory within the same ZFS dataset. For example, the 
+snapshot :file:`mypool/dataset/snap1@snap2` is mounted at :file:`/mnt/mypool/dataset/.zfs/snapshot/snap2/`. If this exceeds 
+88 characters then the snapshot will not be automatically mounted by ZFS and the snapshot contents will not be visible or 
+searchable. This can be resolved by renaming the ZFS pool or dataset containing the snapshot to shorter names (:file:`mypool`
+or :file:`dataset`) or shortening the second part of the snapshot name is shortened (:file:`snap2`), so that the total length
+does not exceed 88 characters. 
 
-- **Manual mount:** If the same snapshot were mounted manually, using 
+- **Manual mount:** If the same snapshot is to be mounted manually from the :ref:`CLI`:, using 
 :command:`mount -t zfs mypool/dataset/snap1@snap2 /mnt/mymountpoint` then the path :file:`/mnt/mountpoint/` 
-must not exceed 88 characters. (Note: a snapshot which cannot be automatically mounted can still be manually mounted if 
-an appropriate short mountpoint path is used)
+must not exceed 88 characters. 
+
+.. note:: A snapshot that cannot be mounted automatically by ZFS, can still be mounted manually from the :ref:`CLI` using a shorter mountpoint path, making it possible to mount snapshots that cannot be mounted automatically by the GUI.

--- a/userguide/snippets/pathlengths.rst
+++ b/userguide/snippets/pathlengths.rst
@@ -34,7 +34,8 @@ can also reduce the length of these limits by one or more bytes.
    | Names               |                |                                                                        |
    +---------------------+----------------+------------------------------------------------------------------------+
    | Mounted Filesystem  | 88 bytes       | Mounted filesystem path length (*MNAMELEN*). Longer paths can prevent  |
-   | Paths               |                | a device from being mounted.                                           |
+   | Paths               |                | a device from being mounted.  See below for examples of path length    |
+   |                     |                | calculation.                                                           |
    +---------------------+----------------+------------------------------------------------------------------------+
    | Device Filesystem   | 63 bytes       | `devfs(8)                                                              |
    | Paths               |                | <https://www.freebsd.org/cgi/man.cgi?query=devfs&sektion=8>`__ device  |
@@ -42,3 +43,18 @@ can also reduce the length of these limits by one or more bytes.
    |                     |                | being created.                                                         |
    +---------------------+----------------+------------------------------------------------------------------------+
 
+Care is needed with regard to ZFS snapshots. **If the mounted path length for a snapshot exceeds 88 characters, 
+then the snapshot and its data will be safe but inaccessible until its mounted path length is reduced**. 
+Typically this is rectified by renaming (shortening) the dataset, snapshot, or mountpoint, so that the path length is
+below the 88 byte limit. Note that ZFS snapshots are automatically mounted on demand within hidden :file:`/.zfs/snapshot/`
+directories, and can also be manually mounted using the command line. The 88 byte limit affects both types of mount.
+
+Examples:
+
+- **Automatic mount:** Any time a user attempts to navigate to a snapshot, or search or access its contents, ZFS must temporarily mount the snapshot. Typically the snapshot :file:`mypool/dataset/snap1@snap2` will be mounted at the path
+:file:`/mnt/mypool/dataset/.zfs/snapshot/snap2/`, which must not exceed 88 characters. 
+
+- **Manual mount:** If the same snapshot were mounted manually, using 
+:command:`mount -t zfs mypool/dataset/snap1@snap2 /mnt/mymountpoint` then the path :file:`/mnt/mountpoint/` 
+must not exceed 88 characters. (Note: a snapshot which cannot be automatically mounted can still be manually mounted if 
+an appropriate short mountpoint path is used)

--- a/userguide/snippets/pathlengths.rst
+++ b/userguide/snippets/pathlengths.rst
@@ -44,14 +44,15 @@ can also reduce the length of these limits by one or more bytes.
    +---------------------+----------------+------------------------------------------------------------------------+
 
 Care is needed with regard to ZFS snapshots. **If the mounted path length for a snapshot exceeds 88 characters, 
-then the snapshot and any contained data will be safe but inaccessible until the mounted path length of the snapshot has been shortened**. Typically this is done by renaming (shortening) the dataset or snapshot, so that the path length is
-below the 88 byte limit. ZFS will perform any necessary unmount or remount of the file system as part of the rename. 
-If the mountpoint is to be renamed, then any object mounted on the mountpoint must be unmounted before renaming, and
-can be remounted after. :command:`umount /mnt/mymountpoint` can be used to unmount a file system.
+then the snapshot and any contained data will be safe but inaccessible until the mounted path length of the snapshot has been shortened**. Typically this is done by **renaming the pool, dataset or snapshot** to shorter names, so that the path length is
+below the 88 byte limit. ZFS will perform any necessary unmount or remount of the file system if a pool, dataset or 
+snapshot are renamed. If the **mountpoint** is to be renamed instead, then any object mounted on the mountpoint must
+be manually unmounted using the :command:`CLI` before renaming, and can be remounted after. 
+:command:`umount /mnt/mymountpoint` can be used to unmount a file system.
 
-ZFS automatically mounts snapshots within hidden :file:`/.zfs/snapshot/` directories, when an attempt is made to access 
-their contents. Snapshots can also be manually mounted (to any valid location) from the command line. The 88 byte limit 
-will affect both types of mount.
+As well as snapshots being manually mounted from the command line, ZFS automatically mounts snapshots within 
+hidden :file:`/.zfs/snapshot/` directories, whenever an attempt is made to access their contents. The 88 byte limit 
+affects both types of mount.
 
 Examples:
 
@@ -59,8 +60,8 @@ Examples:
 mountpoint used will be a hidden :file:`.zfs/snapshot/snapshotname` directory within the same ZFS dataset. For example, the 
 snapshot :file:`mypool/dataset/snap1@snap2` is mounted at :file:`/mnt/mypool/dataset/.zfs/snapshot/snap2/`. If this exceeds 
 88 characters then the snapshot will not be automatically mounted by ZFS and the snapshot contents will not be visible or 
-searchable. This can be resolved by renaming the ZFS pool or dataset containing the snapshot to shorter names (:file:`mypool`
-or :file:`dataset`) or shortening the second part of the snapshot name is shortened (:file:`snap2`), so that the total length
+searchable. This can be resolved either by renaming the ZFS pool or dataset containing the snapshot to shorter names (:file:`mypool`
+or :file:`dataset`) or by shortening the second part of the snapshot name (:file:`snap2`), so that the total length
 does not exceed 88 characters. 
 
 - **Manual mount:** If the same snapshot is to be mounted manually from the :ref:`CLI`:, using 


### PR DESCRIPTION
This is important so a user can understand what exact path components are measured, when considering if a snapshot will be accessible, or fixing a snapshot that isn't accessible.

As Dru noted on forum, it isn't well documented ( https://forums.freenas.org/index.php?threads/snapshot-mounting-limits-clarification-of-freenas-guide.60633 ).