### PR TITLE
Edit "dedup" section

### DIFF
--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -793,7 +793,7 @@ GB of RAM per TB of deduplicated storage. The exact size required for
 deduplication data is found by using the :command:`CLI` command 
 :command:`zdb -U /data/zfs/zpool.cache -D pool_name` to identify the 
 total number of blocks in the pool, and the number of bytes of RAM 
-required per block (shown as *"{number) in core"* in the output). The 
+required per block (shown as *"{number} in core"* in the output). The 
 command  :command:`zdb -U /data/zfs/zpool.cache -S pool_name` 
 displays an estimate of the storage saving if deduplication is 
 applied to a dataset. Note that these commands may take a long time 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -723,60 +723,61 @@ Deduplication
 Deduplication ("dedup") is a process where ZFS aims to store a single copy
 of any data that is repeated in different blocks or files, rather than storing 
 identical copies each time the data occurs. Deduplication 
-potentially allows repeated and identical data to be stored very 
-efficiently in a smaller space, but also places a 
-very heavy burden on RAM and on the CPU. In particular, dedup 
-significantly reduces write performance and usually requires large (and at 
-times huge) amounts of RAM.  See :ref:`Deduplication RAM requirements` for details.
-Because of the demands that dedup places on a system and the impact on performance, 
-enabling dedup is **usually not recommended** and the setting should be left in
-the default setting ("off") in most situations.
+allows repeated and identical data to be stored very 
+efficiently in a smaller space. 
+
+Deduplication can be enabled during dataset creation, and 
+occurs at the time when files are read and written. The setting can 
+be changed at any time but will not affect data already written to 
+the pool.  
+
+Deduplication can require **very large amounts of RAM** and substantial impacts write 
+performance and CPU usage.  See :ref:`Deduplication RAM requirements` for details.
+
+Due to the demands that deduplication places on a system and the impact on performance,
+deduplication is **off by default**. Enabling deduplication without good reason is
+**not usually recommended** unless there are good reasons for doing so, the system has 
+sufficient RAM and CPU, and the performance impact has been tested on a sample of data and
+is acceptable.
 
 .. warning::
 
    The more data written to a deduplicated dataset, the more RAM it 
-   requires. The DDTs (dedup tables) also compete with other data for RAM,
-   and can be pushed out of RAM in some cases. When the system starts 
-   storing DDTs on disk because they no longer fit into RAM or have been
-   pushed out of RAM, performance craters.
+   requires. The deduplication tables (DDT) also compete with other data for RAM,
+   and can be pushed out of RAM and onto disk in some cases. Performance will be 
+   unacceptable if DDTs cannot be managed entirely in RAM.
    
-   Importing an unclean deduplicated pool can also require large amounts of RAM, 
-   so that the deduplicated data in the pool can be checked during import. 
-   If the system does not have the needed RAM, it will panic. The only 
-   solution then is to add more RAM or recreate the pool.
+Importing an unclean deduplicated pool can also require large amounts of RAM, 
+so that the deduplicated data in the pool can be checked during import. A system
+panic will occur if the import process runs out of RAM while running. The only 
+solution then is to add more RAM or recreate the pool.
 
-   **There is also no quick way to undedup data within a dataset once deduplication 
-   is enabled, since disabling deduplication DOES NOT CHANGE existing data.** The 
-   simplest way to undedup existing data is to copy the deduped data to a new dataset 
-   or location that does not have dedup set. The data will be undeduped when written. 
-   The simplest way to undedup data and keep it in the same pool, zvol or dataset is 
-   as follows: disable dedup on the pool, zvol or dataset, then copy the data within 
-   the same pool, zvol or dataset. Once the copy is confirmed to be correct, the 
-   original data can optionally be deleted. If the pool does not have enough free space
-   for this procedure, then disable dedup, copy the data to another system or storage
-   device, check the copies are correct and safe, then delete the original data, and 
-   transfer back the copied data to the pool.
+**There is also no quick way to undedup data within a dataset once deduplication 
+is enabled, since disabling deduplication DOES NOT CHANGE existing data.** The procedure for removing deduplication varies depending upon the specific situation:
 
-   For these reasons, **think carefully before enabling dedup!** 
-   Deduplication is **usually not recommended unless the data contains a 
-   very substantial level of duplication, and the system (especially 
-   RAM) can cope acceptably with the additional burden**. In most cases, 
-   compression provides storage gains comparable to deduplication with 
-   less impact on performance.  This `article 
-   <http://constantin.glez.de/blog/2011/07/zfs-dedupe-or-not-dedupe>`_ 
-   provides a good description of the value versus cost considerations 
-   for deduplication. Unless a lot of RAM and a lot of highly duplicate 
-   data is available, **do not change the default deduplication setting 
-   of "Off"!**  
+* **To remove deduplication but keep the data:**  copy the deduped data to a new dataset 
+  or location that does not have dedup set. The data will be undeduped when written. 
 
-In %brand%, deduplication can be enabled during dataset creation, and 
-occurs at the time when files are read and written. The setting can 
-be changed at any time but will not affect data already written to 
-the pool.  If the deduplication method is set to *Verify*, ZFS will 
-do a byte-to-byte comparison when two blocks have the same hash signature 
-to make sure that the block contents are indeed identical. Since hash 
-collisions are extremely unblikely, *Verify* is usually not worth the 
-performance hit.
+* **To remove deduplication but keep the data in the same pool, zvol or dataset:**
+  disable deduplication on the pool, zvol or dataset, then copy the data within 
+  the same pool, zvol or dataset. The data will be copied without deduplication. 
+  Once the copy is confirmed to be correct, the original data can optionally be deleted.
+
+* **To remove deduplication but keep the data in the same pool, zvol or dataset,
+  if the pool does not have enough free capacity for the procedure above:**
+  disable deduplication, copy the data to a *different* system or storage device, 
+  check the copies are correct and safe, then delete the original data and finally, 
+  copy the copied data back to the original pool.
+
+In summary: **think carefully before enabling deduplication**. 
+Deduplication should only ever be considered if the data contains a 
+very substantial level of duplication, and the system (especially 
+RAM) can cope acceptably with the additional burden. In most cases, 
+compression provides storage gains comparable to deduplication with 
+less impact on performance.  This `article 
+<http://constantin.glez.de/blog/2011/07/zfs-dedupe-or-not-dedupe>`_ 
+provides a good description of the value versus cost considerations 
+for deduplication. 
 #endif freenas
 
 .. tip:: Deduplication is often considered when using a group of very
@@ -788,6 +789,16 @@ performance hit.
    overhead.
 
 #ifdef freenas
+.. _Deduplication method:
+
+Deduplication method
+--------------------
+If the deduplication method is set to *Verify*, ZFS will 
+do a byte-to-byte comparison when two blocks have the same hash signature 
+to make sure that the block contents are indeed identical. Since hash 
+collisions are extremely unblikely, *Verify* is usually not worth the 
+performance hit.
+
 .. _Deduplication RAM requirements:
 
 Deduplication RAM requirements

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -723,13 +723,14 @@ Deduplication
 Deduplication ("dedup") is a process where ZFS aims to store a single copy
 of any data that is repeated in different blocks or files, rather than storing 
 identical copies each time the data occurs. Deduplication 
-potentially allows a large number of very similar data to be stored very 
-efficiently in a smaller space, if there is a lot of identical data, but also places a 
-very heavy burden on RAM and on the CPU. In particular, dedup  
-significantly slows down data write performance and usually requires large (and at 
+potentially allows repeated and identical data to be stored very 
+efficiently in a smaller space, but also places a 
+very heavy burden on RAM and on the CPU. In particular, dedup 
+significantly reduces write performance and usually requires large (and at 
 times huge) amounts of RAM.  See :ref:`Deduplication RAM requirements` for details.
 Because of the demands it places on a system and the impact on performance, dedup
-is **not recommended** and should be left in the default setting ("off") in most situations.
+is **usually not recommended** and should be left in the default setting 
+("off") in most situations.
 
 .. warning::
 
@@ -769,9 +770,9 @@ In %brand%, deduplication can be enabled during dataset creation, and
 occurs at the time when files are read and written. The setting can 
 be changed at any time but will not affect data already written to 
 the pool.  If the deduplication method is set to *Verify*, ZFS will 
-do a byte-to-byte comparison when two blocks have the same signature 
-to make sure that the block contents are identical. Since hash 
-collisions are extremely rare, *Verify* is usually not worth the 
+do a byte-to-byte comparison when two blocks have the same hash signature 
+to make sure that the block contents are indeed identical. Since hash 
+collisions are extremely unblikely, *Verify* is usually not worth the 
 performance hit.
 #endif freenas
 
@@ -791,7 +792,7 @@ Deduplication RAM requirements
 
 It is often said that ZFS needs about 5 GB of RAM per terabyte of deduplicated 
 storage. However this may not be the case, depending on the data to be deduped. A 
-highly duplicated pool capabe of around 3x to 5x space saving may only need as little 
+highly duplicated pool capable of around 3x to 5x space saving may only need as little 
 as 1 or 2 GB of RAM per TB of data. The exact size required for deduplication data is 
 calculated from the output of the :command:`CLI` command :command:`zdb -U 
 /data/zfs/zpool.cache -D pool_name`, which states the total number of blocks in the 
@@ -806,18 +807,18 @@ ZFS uses RAM for many purposes. Therefore ZFS limits the amount of metadata
 main data cache ("ARC"). By default, DDTs and other file system metadata use up to 
 25% of ARC. Therefore if a system has 32 GB of RAM and 20 GB is available for ZFS, 
 ZFS would aim to apportion this 25% (5 GB) for metadata and 75% (15 GB) for file 
-data. The DDTs culd not rely on more than 5 GB of RAM (and perhaps less), which may 
+data. DDTs could not rely on more than 5 GB of RAM (and perhaps less), which may 
 only allow dedup of 1 TB in many cases.
 
-On systems with a large amount of RAM, metadata can use more RAM at the expense of 
-file cache data. For example: suppose that a 12 TB pool requires 30 GB for the DDTs 
+On systems with a large amount of RAM, where dedup is a possibility, more RAM can be
+reserved for metadata at the expense of file cache data. 
+For example: suppose that a 12 TB pool requires 30 GB for the DDTs 
 (2.5 GB per TB). On a system with 64 GB of RAM, the user could reserve 40 GB for 
 metadata and DDT, and leave the rest (24 GB) for the system, jails, and other file 
 cache. This would be done by creating a :ref:`Tunable` called :command:
 `vfs.zfs.arc_meta_limit` of type *loader*, and entering the amount of RAM to be used 
 for metadata, using G for GB or M for MB (in this case, 40G). The setting requires a 
 reboot to become activated. 
-
 #endif freenas
 
 .. index:: Compression

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -735,8 +735,8 @@ Deduplication can require **very large amounts of RAM** and substantial impacts 
 performance and CPU usage.  See :ref:`Deduplication RAM requirements` for details.
 
 Due to the demands that deduplication places on a system and the impact on performance,
-deduplication is **off by default**. Enabling deduplication without good reason is
-**not usually recommended** unless there are good reasons for doing so, the system has 
+deduplication is **off** by default and **should not be enabled** unless there
+are good reasons for doing so, the system has 
 sufficient RAM and CPU, and the performance impact has been tested on a sample of data and
 is acceptable.
 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -814,9 +814,9 @@ data. DDTs could not rely on more than 5 GB of RAM (and perhaps less), which may
 only allow dedup of 1 TB in many cases.
 
 On systems with a large amount of RAM, where dedup is a possibility, more RAM can be
-reserved for metadata at the expense of file cache data. 
-For example: suppose that a 12 TB pool requires 30 GB for the DDTs 
-(2.5 GB per TB). On a system with 64 GB of RAM, the user could reserve 40 GB for 
+reserved for metadata at the expense of file cache data. For example: suppose that 
+deduping 12 TB of undeduped data requires 30 GB of RAM for the DDTs (2.5 GB per TB). 
+On a system with 64 GB of RAM, the user could reserve 40 GB for 
 metadata and DDT, and leave the rest (24 GB) for the system, jails, and other file 
 cache. This would be done by creating a :ref:`Tunable` called :command:
 `vfs.zfs.arc_meta_limit` of type *loader*, and entering the amount of RAM to be used 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -796,14 +796,14 @@ Deduplication RAM requirements
 It is often said that ZFS needs about 5 GB of RAM per terabyte of deduplicated 
 storage. However this may not be the case, depending on the data to be deduped. A 
 highly duplicated pool capable of around 3x to 5x space saving may only need as little 
-as 1 or 2 GB of RAM per TB of data. The exact size required for deduplication data is 
-calculated from the output of the :command:`CLI` command :command:`zdb -U 
-/data/zfs/zpool.cache -D pool_name`, which states the total number of blocks in the 
-pool, and the number of bytes of RAM required per block (shown as *"{number} in 
-core"*). The command :command:`zdb -U /data/zfs/zpool.cache -S pool_name` also 
-provides an estimate of the storage saving if deduplication is applied to a dataset 
-or zvol. These commands may take a long time to run because they scan the entire pool 
-to produce the results.
+as 1 or 2 GB of RAM per TB of data. The exact size required for DDTs in a deduped pool, 
+dataset or zvol is calculated from the output of the :command:`CLI` command 
+:command:`zdb -U /data/zfs/zpool.cache -D pool_name`, which states the total number of
+blocks in the pool, and the number of bytes of RAM required per block (shown as
+*"{number} in core"*). The command :command:`zdb -U /data/zfs/zpool.cache -S pool_name`
+calculates the storage saving that would be achieved for a pool, dataset or zvol, if the 
+data within it were to be completely deduped. These commands may take a long time to run
+because they scan the entire pool to produce the results.
 
 ZFS uses RAM for many purposes. Therefore ZFS limits the amount of metadata 
 (including DDT data) for which space is reserved in RAM. ZFS stores DDT data in its 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -810,11 +810,15 @@ for metadata and 75% (15 GB) for file data. The DDTs can rely on not more
 than 5 GB of RAM (and perhaps less), which may only allow dedup of 
 1 TB in many cases.
 
-If the system has a large amount of RAM, metadata can be allowed to use
-much more RAM, at the expense of file cache data. This can be done by
-creating a :ref:`Tunable` called :command:`vfs.zfs.arc_meta_limit` of
-type *loader*, and entering the amount of RAM to be used for metadata in 
-bytes. The new setting requires a reboot to becoms activated.
+If the system has a large amount of RAM, metadata can use more RAM, at 
+the expense of file cache data. For example: suppose that a 20 TB pool with
+a dedup ratio of 3x space saving is found to require 40 GB total for the DDT 
+(2 GB per TB). If the system has 96GB of RAM then the user could reserve 
+60 GB for metadata and DDT, and leave the rest (36 GB) for the system and
+other file cache.  This would  be done by creating a :ref:`Tunable` called 
+:command:`vfs.zfs.arc_meta_limit` of type *loader*, and entering the amount 
+of RAM to be used for metadata. The value can be abbreviated using G for GB
+or M for MB (in this case, 60G). The setting requires a reboot to become activated.
 
 #endif freenas
 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -725,11 +725,11 @@ of any data that is repeated in different blocks or files, rather than storing
 identical copies each time the data occurs. Deduplication 
 potentially allows a large number of very similar data to be stored very 
 efficiently in a smaller space, if there is a lot of identical data, but also places a 
-very heavy burden on RAM and on the CPU. In particular, dedup can 
-significantly slow down data write performance and usually requires large (and at 
+very heavy burden on RAM and on the CPU. In particular, dedup  
+significantly slows down data write performance and usually requires large (and at 
 times huge) amounts of RAM.  See :ref:`Deduplication RAM requirements` for details.
-Because of the demands it places on a system, dedup is **not recommended** and should 
-be left in the default setting ("off") in most situations.
+Because of the demands it places on a system and the impact on performance, dedup
+is **not recommended** and should be left in the default setting ("off") in most situations.
 
 .. warning::
 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -713,13 +713,14 @@ existing datasets to close them--the remaining
 Deduplication
 ^^^^^^^^^^^^^
 
-Deduplication is the process of storing one copy of any data that is 
-found to be duplicated between different files. The result is that 
-only unique data is stored and common components are shared among 
-files.  Deduplication potentially allows a large number of very 
+Deduplication (often just called "dedup") is the process of storing 
+just one copy of any data that is found to be the same in different 
+files. The aim is that only unique data is physically stored, rather
+than another identical copy being stored for every file which contains 
+that data. Deduplication potentially allows a large number of very 
 similar files to be held very efficiently within a much smaller 
-amount of storage capacity, if the data contains numerous very 
-similar files or blocks.  However, deduplication also places a very 
+amount of storage capacity, if the data contains numerous identical 
+files or blocks of data.  However, deduplication also places a very 
 heavy burden on RAM and on the CPU, and in particular, deduplication 
 can significantly slow down data write performance and usually requires
 large (and at times huge) amounts of RAM. See 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -811,10 +811,10 @@ than 5 GB of RAM (and perhaps less), which may only allow dedup of
 1 TB in many cases.
 
 If the system has a large amount of RAM, metadata can use more RAM, at 
-the expense of file cache data. For example: suppose that a 20 TB pool with
-a dedup ratio of 3x space saving is found to require 40 GB total for the DDT 
-(2 GB per TB). If the system has 96GB of RAM then the user could reserve 
-60 GB for metadata and DDT, and leave the rest (36 GB) for the system and
+the expense of file cache data. For example: suppose that a 12 TB pool with
+a dedup ratio of 3x space saving is found to require 30 GB total for the DDT 
+(2.5 GB per TB). If the system has 64 GB of RAM then the user could reserve 
+40 GB for metadata and DDT, and leave the rest (24 GB) for the system, jails, and
 other file cache.  This would  be done by creating a :ref:`Tunable` called 
 :command:`vfs.zfs.arc_meta_limit` of type *loader*, and entering the amount 
 of RAM to be used for metadata. The value can be abbreviated using G for GB

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -728,9 +728,9 @@ efficiently in a smaller space, but also places a
 very heavy burden on RAM and on the CPU. In particular, dedup 
 significantly reduces write performance and usually requires large (and at 
 times huge) amounts of RAM.  See :ref:`Deduplication RAM requirements` for details.
-Because of the demands it places on a system and the impact on performance, dedup
-is **usually not recommended** and should be left in the default setting 
-("off") in most situations.
+Because of the demands that dedup places on a system and the impact on performance, 
+enabling dedup is **usually not recommended** and the setting should be left in
+the default setting ("off") in most situations.
 
 .. warning::
 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -733,8 +733,8 @@ large (and at times huge) amounts of RAM. See
    storing DDTs on disk because they no longer fit into RAM or have been
    pushed out of RAM, performance craters.
    
-   Importing an unclean pool canalso require very large amounts of RAM, 
-   to allow the deduplicated data in the pool to be checked before import. 
+   Importing an unclean deduplicated pool can also require large amounts of RAM, 
+   so that the deduplicated data in the pool can be checked during import. 
    If the system does not have the needed RAM, it will panic. The only 
    solution then is to add more RAM or recreate the pool.
 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -723,21 +723,22 @@ similar files or blocks.  However, deduplication also places a very
 heavy burden on RAM and on the CPU, and in particular, deduplication 
 can significantly slow down data write performance. 
 
+A generally quoted rule of thumb is 5 GB of RAM per terabyte of 
+deduplicated storage, however if the pool is highly duplicated 
+(around 3x to 5x space saving) this can drop to as low as 1 GB to 2 
+GB of RAM per TB of deduplicated storage. The exact size required for 
+deduplication data is found by using the :command:`CLI` command 
+:command:`zdb -U /data/zfs/zpool.cache -D pool_name` to identify the 
+total number of blocks in the pool, and the number of bytes of RAM 
+required per block (shown as "<number> in core" in the output). The 
+command  :command:`zdb -U /data/zfs/zpool.cache -S pool_name` 
+displays an estimate of the storage saving if deduplication is 
+applied to a dataset. Note that these commands may take a long time 
+to run because they scan the entire pool to produce the results. 
+   
 .. warning::
 
-   A generally quoted rule of thumb is 5 GB of RAM per terabyte of 
-   deduplicated storage, however if the pool is highly duplicated 
-   (around 3x to 5x space saving) this can drop to as low as 1 GB to 2 
-   GB of RAM per TB of deduplicated storage. The exact size required for 
-   deduplication data is found by using the :command:`CLI` command 
-   :command:`zdb -U /data/zfs/zpool.cache -D pool_name` to identify the 
-   total number of blocks in the pool, and the number of bytes of RAM 
-   required per block (shown as "<number> in core" in the output). The 
-   command  :command:`zdb -U /data/zfs/zpool.cache -S pool_name` 
-   displays an estimate of the storage saving if deduplication is 
-   applied to a dataset. Note that these commands may take a long time 
-   to run because they scan the entire pool to produce the results. The
-   more data written to a deduplicated dataset, the more RAM it 
+   The more data written to a deduplicated dataset, the more RAM it 
    requires. When the system starts storing the DDTs (dedup tables) on 
    disk because they no longer fit into RAM, performance craters. 
    Further, importing an unclean pool can require similar amounts of RAM 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -730,7 +730,7 @@ GB of RAM per TB of deduplicated storage. The exact size required for
 deduplication data is found by using the :command:`CLI` command 
 :command:`zdb -U /data/zfs/zpool.cache -D pool_name` to identify the 
 total number of blocks in the pool, and the number of bytes of RAM 
-required per block (shown as "<number> in core" in the output). The 
+required per block (shown as *"{number) in core"* in the output). The 
 command  :command:`zdb -U /data/zfs/zpool.cache -S pool_name` 
 displays an estimate of the storage saving if deduplication is 
 applied to a dataset. Note that these commands may take a long time 
@@ -739,13 +739,16 @@ to run because they scan the entire pool to produce the results.
 .. warning::
 
    The more data written to a deduplicated dataset, the more RAM it 
-   requires. When the system starts storing the DDTs (dedup tables) on 
-   disk because they no longer fit into RAM, performance craters. 
-   Further, importing an unclean pool can require similar amounts of RAM 
-   and if the system does not have the needed RAM, it will panic. The 
-   only solution then is to add more RAM or recreate the pool.  
+   requires. The DDTs (dedup tables) also compete with other data for RAM,
+   and can be pushed out of RAM in some cases. When the system starts 
+   storing DDTs on disk because they no longer fit into RAM or have been
+   pushed out of RAM, performance craters.
+   
+   Importing an unclean pool can require similar amounts of RAM. If
+   the system does not have the needed RAM, it will panic. The only solution
+   then is to add more RAM or recreate the pool.
 
-   Furthermore, **there is no quick way to undedup data 
+   **There is also no quick way to undedup data 
    within a dataset once deduplication is enabled**, as disabling 
    deduplication has **NO EFFECT** on existing data. The simplest way to 
    undedup existing data is to copy the deduped files to a new undeduped 
@@ -777,6 +780,13 @@ do a byte-to-byte comparison when two blocks have the same signature
 to make sure that the block contents are identical. Since hash 
 collisions are extremely rare, *Verify* is usually not worth the 
 performance hit.
+
+.. tip::
+   The amount of RAM cache (known as ARC) that ZFS reserves for the DDTs and other 
+   file system metadata is set by default at 25% of ARC. It may be necessary to 
+   manually increase this value in some cases where dedup is used. This can 
+   be done by creating a :ref:`Tunable` called :command:`vfs.zfs.arc_meta_limit` 
+   of type *loader*, and entering the amount of RAM to be used for metadata in bytes.
 #endif freenas
 
 .. tip:: Deduplication is often considered when using a group of very

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -818,7 +818,7 @@ a dedup ratio of 3x space saving is found to require 30 GB total for the DDT
 other file cache.  This would  be done by creating a :ref:`Tunable` called 
 :command:`vfs.zfs.arc_meta_limit` of type *loader*, and entering the amount 
 of RAM to be used for metadata. The value can be abbreviated using G for GB
-or M for MB (in this case, 60G). The setting requires a reboot to become activated.
+or M for MB (in this case, 40G). The setting requires a reboot to become activated.
 
 #endif freenas
 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -746,7 +746,7 @@ the default setting ("off") in most situations.
    solution then is to add more RAM or recreate the pool.
 
    **There is also no quick way to undedup data within a dataset once deduplication 
-   is enabled**, since disabling deduplication **DOES NOT CHANGE** existing data. The 
+   is enabled, since disabling deduplication DOES NOT CHANGE existing data.** The 
    simplest way to undedup existing data is to copy the deduped data to a new dataset 
    or location that does not have dedup set. The data will be undeduped when written. 
    The simplest way to undedup data and keep it in the same pool, zvol or dataset is 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -802,7 +802,7 @@ dataset or zvol is calculated from the output of the :command:`CLI` command
 blocks in the pool, and the number of bytes of RAM required per block (shown as
 *"{number} in core"*). The command :command:`zdb -U /data/zfs/zpool.cache -S pool_name`
 calculates the storage saving that would be achieved for a pool, dataset or zvol, if the 
-data within it were to be completely deduped. These commands may take a long time to run
+data within it were completely deduped. These commands may take a long time to run
 because they scan the entire pool to produce the results.
 
 ZFS uses RAM for many purposes. Therefore ZFS limits the amount of metadata 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -720,7 +720,7 @@ Deduplication
 Deduplication
 ^^^^^^^^^^^^^
 
-Deduplication ("dedup") is a process where ZFS aims to store a single copy
+Deduplication, or "dedup", is a process where ZFS aims to store a single copy
 of any data that is repeated in different blocks or files, rather than storing 
 identical copies each time the data occurs. Deduplication 
 allows repeated and identical data to be stored very 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -733,9 +733,10 @@ large (and at times huge) amounts of RAM. See
    storing DDTs on disk because they no longer fit into RAM or have been
    pushed out of RAM, performance craters.
    
-   Importing an unclean pool can require similar amounts of RAM. If
-   the system does not have the needed RAM, it will panic. The only solution
-   then is to add more RAM or recreate the pool.
+   Importing an unclean pool canalso require very large amounts of RAM, 
+   to allow the deduplicated data in the pool to be checked before import. 
+   If the system does not have the needed RAM, it will panic. The only 
+   solution then is to add more RAM or recreate the pool.
 
    **There is also no quick way to undedup data 
    within a dataset once deduplication is enabled**, as disabling 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -752,7 +752,10 @@ the default setting ("off") in most situations.
    The simplest way to undedup data and keep it in the same pool, zvol or dataset is 
    as follows: disable dedup on the pool, zvol or dataset, then copy the data within 
    the same pool, zvol or dataset. Once the copy is confirmed to be correct, the 
-   original data can optionally be deleted.
+   original data can optionally be deleted. If the pool does not have enough free space
+   for this procedure, then disable dedup, copy the data to another system or storage
+   device, check the copies are correct and safe, then delete the original data, and 
+   transfer back the copied data to the pool.
 
    For these reasons, **think carefully before enabling dedup!** 
    Deduplication is **usually not recommended unless the data contains a 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -731,7 +731,7 @@ occurs at the time when files are read and written. The setting can
 be changed at any time but will not affect data already written to 
 the pool.  
 
-Deduplication can require **very large amounts of RAM** and substantial impacts write 
+Deduplication can require **very large amounts of RAM** and substantially impacts both write 
 performance and CPU usage.  See :ref:`Deduplication RAM requirements` for details.
 
 Due to the demands that deduplication places on a system and the impact on performance,

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -722,13 +722,14 @@ Deduplication
 
 Deduplication ("dedup") is a process where ZFS aims to store a single copy
 of any data that is repeated in different blocks or files, rather than storing 
-another identical block or file copy each time it occurs. Deduplication 
-potentially allows a large number of very similar files to be held very 
-efficiently within a much smaller amount of storage capacity, if the data contains 
-numerous identical files or blocks of data. However, deduplication also places a 
-very heavy burden on RAM and on the CPU, and in particular, deduplication can 
+identical copies each time the data occurs. Deduplication 
+potentially allows a large number of very similar data to be stored very 
+efficiently in a smaller space, if there is a lot of identical data, but also places a 
+very heavy burden on RAM and on the CPU. In particular, dedup can 
 significantly slow down data write performance and usually requires large (and at 
-times huge) amounts of RAM. See :ref:`Deduplication RAM requirements` for details.
+times huge) amounts of RAM.  See :ref:`Deduplication RAM requirements` for details.
+Because of the demands it places on a system, dedup is **not recommended** and should 
+be left in the default setting ("off") in most situations.
 
 .. warning::
 


### PR DESCRIPTION
The general info repeats a lot (memory amounts, inability to undedup existing data, warnings), is inaccurate in part (dedup only needs 1 - 2 GB per TB **if used when actually appropriate**, i.e., when there are high duplicate data levels), and misses out crucial detail (how to tell how much dup data you have, and the fact that other ARC usage can push DDT metadata out of RAM!)

I've grouped "like with like" and organised it - hopefully better - and added the missing info.

I'm not sure how to format the warning paragraphs, as a lot of the "be careful and try to avoid dedup" is really warning text. Perhaps a separate section? Maybe you can suggest a better way. 

I also don't remember how to format the link to "Tunable/Tunables", can you advise or correct?