### PR TITLE
Link review and syntax update:

### DIFF
--- a/userguide/account.rst
+++ b/userguide/account.rst
@@ -91,8 +91,8 @@ summarizes the available options when creating a group.
    | Group Name          | string    | mandatory                                                                                                                |
    |                     |           |                                                                                                                          |
    +---------------------+-----------+--------------------------------------------------------------------------------------------------------------------------+
-   | Permit Sudo         | checkbox  | if checked, members of the group have permission to use `sudo <http://www.sudo.ws/>`_; when using sudo, a user will      |
-   |                     |           | be prompted for their own password                                                                                       |
+   | Permit Sudo         | checkbox  | if checked, members of the group have permission to use `sudo <https://www.sudo.ws/>`__; when using sudo, a user         |
+   |                     |           | will be prompted for their own password                                                                                  |
    |                     |           |                                                                                                                          |
    +---------------------+-----------+--------------------------------------------------------------------------------------------------------------------------+
    | Allow repeated GIDs | checkbox  | allows multiple groups to share the same group id (GID); this is useful when a GID is already associated with the        |
@@ -195,7 +195,7 @@ Except for the *root* user, the accounts that come with %brand%
 are system accounts. Each system account is used by a service and
 should not be used as a login account. For this reason, the default
 shell on system accounts is
-`nologin(8) <http://www.freebsd.org/cgi/man.cgi?query=nologin>`__.
+`nologin(8) <https://www.freebsd.org/cgi/man.cgi?query=nologin>`__.
 For security reasons, and to prevent breakage of system services, do
 not modify the system accounts.
 
@@ -287,7 +287,7 @@ created or modified.
    |                            |                 |          | box will gray out :guilabel:`Disable password login` which is mutually exclusive                                                           |
    |                            |                 |          |                                                                                                                                            |
    +----------------------------+-----------------+----------+--------------------------------------------------------------------------------------------------------------------------------------------+
-   | Permit Sudo                | checkbox        |          | if checked, members of the group have permission to use `sudo <http://www.sudo.ws/>`_; when using sudo, a user will be prompted for        |
+   | Permit Sudo                | checkbox        |          | if checked, members of the group have permission to use `sudo <https://www.sudo.ws/>`__; when using sudo, a user will be prompted for      |
    |                            |                 |          | their own password                                                                                                                         |
    |                            |                 |          |                                                                                                                                            |
    +----------------------------+-----------------+----------+--------------------------------------------------------------------------------------------------------------------------------------------+
@@ -324,42 +324,42 @@ created or modified.
    |              | root permissions (effective user ID 0, like *toor*)                                                                  |
    |              |                                                                                                                      |
    +--------------+----------------------------------------------------------------------------------------------------------------------+
-   | csh          | `C shell <https://en.wikipedia.org/wiki/C_shell>`_                                                                   |
+   | csh          | `C shell <https://en.wikipedia.org/wiki/C_shell>`__                                                                  |
    |              |                                                                                                                      |
    +--------------+----------------------------------------------------------------------------------------------------------------------+
-   | sh           | `Bourne shell <https://en.wikipedia.org/wiki/Bourne_shell>`_                                                         |
+   | sh           | `Bourne shell <https://en.wikipedia.org/wiki/Bourne_shell>`__                                                        |
    |              |                                                                                                                      |
    +--------------+----------------------------------------------------------------------------------------------------------------------+
-   | tcsh         | `Enhanced C shell <https://en.wikipedia.org/wiki/Tcsh>`_                                                             |
+   | tcsh         | `Enhanced C shell <https://en.wikipedia.org/wiki/Tcsh>`__                                                            |
    |              |                                                                                                                      |
    +--------------+----------------------------------------------------------------------------------------------------------------------+
    | nologin      | use when creating a system account or to create a user account that can authenticate with shares but which cannot    |
    |              | login to the FreeNAS system using :command:`ssh`                                                                     |
    |              |                                                                                                                      |
    +--------------+----------------------------------------------------------------------------------------------------------------------+
-   | bash         | `Bourne Again shell <https://en.wikipedia.org/wiki/Bash_%28Unix_shell%29>`_                                          |
+   | bash         | `Bourne Again shell <https://en.wikipedia.org/wiki/Bash_%28Unix_shell%29>`__                                         |
    |              |                                                                                                                      |
    +--------------+----------------------------------------------------------------------------------------------------------------------+
-   | ksh93        | `Korn shell <http://www.kornshell.com/>`_                                                                            |
+   | ksh93        | `Korn shell <http://www.kornshell.com/>`__                                                                           |
    |              |                                                                                                                      |
    +--------------+----------------------------------------------------------------------------------------------------------------------+
-   | mksh         | `mirBSD Korn shell <https://www.mirbsd.org/mksh.htm>`_                                                               |
+   | mksh         | `mirBSD Korn shell <https://www.mirbsd.org/mksh.htm>`__                                                              |
    |              |                                                                                                                      |
    +--------------+----------------------------------------------------------------------------------------------------------------------+
-   | rbash        | `Restricted bash <http://www.gnu.org/software/bash/manual/html_node/The-Restricted-Shell.html>`_                     |
+   | rbash        | `Restricted bash <http://www.gnu.org/software/bash/manual/html_node/The-Restricted-Shell.html>`__                    |
    |              |                                                                                                                      |
    +--------------+----------------------------------------------------------------------------------------------------------------------+
-   | rzsh         | `Restricted zsh <http://www.csse.uwa.edu.au/programming/linux/zsh-doc/zsh_14.html>`_                                 |
+   | rzsh         | `Restricted zsh <http://www.csse.uwa.edu.au/programming/linux/zsh-doc/zsh_14.html>`__                                |
    |              |                                                                                                                      |
    +--------------+----------------------------------------------------------------------------------------------------------------------+
-   | scponly      | select `scponly <https://github.com/scponly/scponly/wiki>`_ to restrict the user's SSH usage to only the             |
+   | scponly      | select `scponly <https://github.com/scponly/scponly/wiki>`__ to restrict the user's SSH usage to only the            |
    |              | :command:`scp` and :command:`sftp` commands                                                                          |
    |              |                                                                                                                      |
    +--------------+----------------------------------------------------------------------------------------------------------------------+
-   | zsh          | `Z shell <http://www.zsh.org/>`_                                                                                     |
+   | zsh          | `Z shell <http://www.zsh.org/>`__                                                                                    |
    |              |                                                                                                                      |
    +--------------+----------------------------------------------------------------------------------------------------------------------+
-   | git-shell    | `restricted git shell <http://git-scm.com/docs/git-shell>`_                                                          |
+   | git-shell    | `restricted git shell <https://git-scm.com/docs/git-shell>`__                                                        |
    |              |                                                                                                                      |
    +--------------+----------------------------------------------------------------------------------------------------------------------+
 

--- a/userguide/api.rst
+++ b/userguide/api.rst
@@ -5,7 +5,7 @@ Using the API
 =============
 
 A `REST
-<https://en.wikipedia.org/wiki/Representational_state_transfer>`_ API
+<https://en.wikipedia.org/wiki/Representational_state_transfer>`__ API
 is provided to be used as an alternate mechanism for remotely
 controlling a %brand% system.
 
@@ -17,7 +17,7 @@ such as GET, PUT, POST, or DELETE.
 As shown in
 :numref:`Figure %s <api_fig>`,
 an online version of the API is available at
-`api.freenas.org <http://api.freenas.org>`_.
+`api.freenas.org <http://api.freenas.org>`__.
 
 .. _api_fig:
 
@@ -47,7 +47,7 @@ A Simple API Example
 
 
 The `api directory of the FreeNAS® github repository
-<https://github.com/freenas/freenas/tree/master/examples/api>`_
+<https://github.com/freenas/freenas/tree/master/examples/api>`__
 contains some API usage examples. This section provides a walk-through
 of the :file:`newuser.py` script, shown below, as it provides a simple
 example that creates a user.
@@ -118,7 +118,7 @@ SSL certificate, change *False* to *True*.
 
 **Lines 8-16:** set the values for the user being created. The
 `Users
-resource <http://api.freenas.org/resources/account.html#users>`_
+resource <http://api.freenas.org/resources/account.html#users>`__
 describes this in more detail. Allowed parameters are listed in the
 JSON Parameters section of that resource. Since this resource creates
 a FreeBSD user, the values entered must be valid for a FreeBSD user

--- a/userguide/cli.rst
+++ b/userguide/cli.rst
@@ -53,12 +53,12 @@ will need to install an Iperf client on a desktop system that has
 network access to the %brand% system. This section will demonstrate
 how to use the
 `xjperf GUI client
-<http://code.google.com/p/xjperf/downloads/detail?name=jperf-2.0.2.zip>`_
+<https://code.google.com/archive/p/xjperf/downloads>`__
 as it works on Windows, Mac OS X, Linux, and BSD systems.
 
 Since this client is Java-based, the appropriate
 `JRE
-<http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_
+<http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__
 must be installed on the client computer.
 
 Linux and BSD users will need to install the iperf package using their
@@ -76,8 +76,8 @@ Once the client is ready, you need to start the Iperf server on
 %brand%.
 
 .. note:: Beginning with %brand% version 11.1, both `iperf2
-   <https://sourceforge.net/projects/iperf2/>`_ and `iperf3
-   <http://software.es.net/iperf/>`_ are pre-installed. To use iperf2,
+   <https://sourceforge.net/projects/iperf2/>`__ and `iperf3
+   <http://software.es.net/iperf/>`__ are pre-installed. To use iperf2,
    use :command:`iperf`. To use iperf3, instead type :command:`iperf3`.
    The examples below are for iperf2.
 
@@ -186,7 +186,7 @@ server process using this command:
 The following command will display the available options for
 performing tests with the :command:`netperf` command. The
 `Netperf Manual
-<http://www.netperf.org/svn/netperf2/tags/netperf-2.6.0/doc/netperf.html>`_
+<https://hewlettpackard.github.io/netperf/>`__
 describes each option in more detail and explains how to perform many
 types of tests. It is the best reference for understanding how each
 test works and how to interpret your results. When you are finished
@@ -263,7 +263,7 @@ volume that you have permission to write to, otherwise you will get an
 error about being unable to write the temporary file.
 
 Before using IOzone, read through the `IOzone documentation PDF
-<http://www.iozone.org/docs/IOzone_msword_98.pdf>`_ as it describes
+<http://www.iozone.org/docs/IOzone_msword_98.pdf>`__ as it describes
 the tests, the many command line switches, and how to interpret your
 results.
 
@@ -272,13 +272,13 @@ starting points on which tests to run, when to run them, and how to
 interpret the results:
 
 * `How To Measure Linux Filesystem I/O Performance With iozone
-  <http://www.cyberciti.biz/tips/linux-filesystem-benchmarking-with-iozone.html>`_
+  <https://www.cyberciti.biz/tips/linux-filesystem-benchmarking-with-iozone.html>`__
 
 * `Analyzing NFS Client Performance with IOzone
-  <http://www.iozone.org/docs/NFSClientPerf_revised.pdf>`_
+  <http://www.iozone.org/docs/NFSClientPerf_revised.pdf>`__
 
 * `10 iozone Examples for Disk I/O Performance Measurement on Linux
-  <http://www.thegeekstuff.com/2011/05/iozone-examples/>`_
+  <https://www.thegeekstuff.com/2011/05/iozone-examples>`__
 
 You can receive a summary of the available switches by typing the
 following command. As you can see from the number of options, IOzone
@@ -296,7 +296,7 @@ pool or dataset when running IOzone benchmarks.
 
 .. note:: If you prefer to visualize the collected data, scripts are
    available to render IOzone's output in
-   `Gnuplot <http://www.gnuplot.info/>`_.
+   `Gnuplot <http://www.gnuplot.info/>`__.
 
 ::
 
@@ -413,7 +413,7 @@ arcstat
 -------
 
 Arcstat is a script that prints out ZFS
-`ARC <https://en.wikipedia.org/wiki/Adaptive_replacement_cache>`_
+`ARC <https://en.wikipedia.org/wiki/Adaptive_replacement_cache>`__
 statistics. Originally it was a perl script created by Sun. That perl
 script was ported to FreeBSD and was then ported as a Python script
 for use on %brand%.
@@ -432,7 +432,7 @@ on cached reads, there is cause to investigate further and tune the
 system.
 
 The
-`FreeBSD ZFS Tuning Guide <https://wiki.FreeBSD.org/ZFSTuningGuide>`_
+`FreeBSD ZFS Tuning Guide <https://wiki.freebsd.org/ZFSTuningGuide>`__
 provides some suggestions for commonly tuned :command:`sysctl` values.
 It should be noted that performance tuning is more of an art than a
 science and that any changes you make will probably require several
@@ -441,13 +441,9 @@ vary depending upon the type of workload and that what works for one
 person's network may not benefit yours.
 
 In particular, the value of pre-fetching depends upon the amount of
-memory and the type of workload, as seen in these two examples:
+memory and the type of workload, as seen in this example:
 
-* `Understanding ZFS: Prefetch
-  <http://www.cuddletech.com/blog/pivot/entry.php?id=1040>`_
-
-* `ZFS prefetch algorithm can cause performance drawbacks
-  <http://southbrain.com/south/2008/04/the-nightmare-comes-slowly-zfs.html>`_
+* `Understanding ZFS: Prefetch <http://cuddletech.com/?p=204>`__
 
 %brand% provides two command line scripts which can be manually run
 from :ref:`Shell`:
@@ -805,13 +801,13 @@ tw_cli
 providing controller, logical unit, and drive management for
 AMCC/3ware ATA RAID Controllers. The supported models are listed in
 the man pages for the
-`twe(4) <http://www.freebsd.org/cgi/man.cgi?query=twe>`_
+`twe(4) <https://www.freebsd.org/cgi/man.cgi?query=twe>`__
 and
-`twa(4) <http://www.freebsd.org/cgi/man.cgi?query=twa>`_
+`twa(4) <https://www.freebsd.org/cgi/man.cgi?query=twa>`__
 drivers.
 
 Before using this command, read its
-`man page <http://www.cyberciti.biz/files/tw_cli.8.html>`_
+`man page <https://www.cyberciti.biz/files/tw_cli.8.html>`__
 as it describes the terminology and provides some usage examples.
 
 If you type :command:`tw_cli` in Shell, the prompt will change,
@@ -910,13 +906,13 @@ MegaCli
 
 :command:`MegaCli` is the command line interface for the Broadcom
 :MegaRAID SAS family of RAID controllers. %brand% also includes the
-`mfiutil(8) <http://www.freebsd.org/cgi/man.cgi?query=mfiutil>`_
+`mfiutil(8) <https://www.freebsd.org/cgi/man.cgi?query=mfiutil>`__
 utility which can be used to configure and manage connected storage
 devices.
 
 The :command:`MegaCli` command is quite complex with several dozen
 options. The commands demonstrated in the `Emergency Cheat Sheet
-<http://tools.rapidsoft.de/perc/perc-cheat-sheet.html>`_ can get you
+<http://tools.rapidsoft.de/perc/perc-cheat-sheet.html>`__ can get you
 started.
 
 
@@ -1018,7 +1014,7 @@ To create a second window, press :kbd:`Ctrl+b` then :kbd:`"`. To close
 a window, type :command:`exit` within the window.
 
 `tmux(1)
-<http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/./man1/tmux.1?query=tmux>`_
+<http://man.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man1/tmux.1?query=tmux>`__
 lists all of the key bindings and commands for interacting with
 :command:`tmux` windows and sessions.
 
@@ -1032,10 +1028,10 @@ first.
 These resources provide more information about using :command:`tmux`:
 
 * `A tmux Crash Course
-  <https://robots.thoughtbot.com/a-tmux-crash-course>`_
+  <https://robots.thoughtbot.com/a-tmux-crash-course>`__
 
 * `TMUX - The Terminal Multiplexer
-  <http://blog.hawkhost.com/2010/06/28/tmux-the-terminal-multiplexer/>`_
+  <http://blog.hawkhost.com/2010/06/28/tmux-the-terminal-multiplexer/>`__
 
 
 .. index:: Dmidecode
@@ -1047,7 +1043,7 @@ Dmidecode
 Dmidecode reports hardware information as reported by the system BIOS.
 Dmidecode does not scan the hardware, it only reports what the BIOS
 told it to. A sample output can be seen
-`here <http://www.nongnu.org/dmidecode/sample/dmidecode.txt>`_.
+`here <http://www.nongnu.org/dmidecode/sample/dmidecode.txt>`__.
 
 To view the BIOS report, type the command with no arguments:
 
@@ -1056,5 +1052,5 @@ To view the BIOS report, type the command with no arguments:
    dmidecode | more
 
 
-`dmidecode(8) <http://linux.die.net/man/8/dmidecode>`_
+`dmidecode(8) <https://linux.die.net/man/8/dmidecode>`__
 describes the supported strings and types.

--- a/userguide/contribute.rst
+++ b/userguide/contribute.rst
@@ -29,14 +29,14 @@ user interface into native languages can make %brand% much more useful
 to communities around the world.
 
 %brand% uses
-`Weblate <https://weblate.org/>`_
+`Weblate <https://weblate.org/en/>`__
 to manage the translation of text shown in the %brand% graphical
 administrative interface. Weblate provides an easy-to-use web-based
 editor and commenting system, making it possible for individuals to
 assist with translation or comment on existing translations.
 
 To see the status of translations, open
-`<http://weblate.trueos.org/projects/freenas/>`_, as shown in
+`<https://weblate.trueos.org/projects/freenas/>`__, as shown in
 :numref:`Figure %s <contribute_weblate_fig>`.
 
 

--- a/userguide/install.rst
+++ b/userguide/install.rst
@@ -57,9 +57,9 @@ verify the checksum varies by operating system:
   :samp:`shasum -a 256 {name_of_file}`
 
 * Windows or Mac users can install additional utilities like
-  `HashCalc <http://www.slavasoft.com/hashcalc/>`_
+  `HashCalc <http://www.slavasoft.com/hashcalc/>`__
   or
-  `HashTab <http://implbits.com/products/hashtab/>`_
+  `HashTab <http://implbits.com/products/hashtab/>`__
 
 The value produced by running the command must match the value shown
 in the :file:`sha256.txt` file.  Checksum values that do not match
@@ -151,13 +151,13 @@ On Windows
 Microsoft provides the USB/DVD Download Tool to create a USB bootable
 image from an :file:`.iso` file. Follow
 `these instructions
-<https://www.microsoft.com/en-us/download/windows-usb-dvd-download-tool>`_,
+<https://www.microsoft.com/en-us/download/windows-usb-dvd-download-tool>`__,
 but enter the name of the downloaded :file:`.iso` into the
 :guilabel:`SOURCE FILE` box.
 
-`Image Writer <https://launchpad.net/win32-image-writer/>`_
+`Image Writer <https://launchpad.net/win32-image-writer/>`__
 and
-`Rufus <http://rufus.akeo.ie/>`_
+`Rufus <http://rufus.akeo.ie/>`__
 are alternate programs for writing images to USB sticks on a computer
 running Windows. When using Rufus, check
 :guilabel:`Create a bootable disk using` and select *DD Image* from
@@ -438,12 +438,12 @@ again.
 If the system starts to boot but hangs at a *mountroot>* prompt,
 follow the instructions in
 `Workaround/Semi-Fix for Mountroot Issues with 9.3
-<https://forums.freenas.org/index.php?threads/workaround-semi-fix-for-mountroot-issues-with-9-3.26071/>`_.
+<https://forums.freenas.org/index.php?threads/workaround-semi-fix-for-mountroot-issues-with-9-3.26071/>`__.
 
 If the burned image fails to boot and the image was burned using a
 Windows system, wipe the USB stick before trying a second burn using a
 utility such as
-`Active@ KillDisk <http://how-to-erase-hard-drive.com/>`_.
+`Active@ KillDisk <http://how-to-erase-hard-drive.com/>`__.
 Otherwise, the second burn attempt will fail as Windows does not
 understand the partition which was written from the image file. Be
 very careful to specify the correct USB stick when using a wipe
@@ -574,7 +574,7 @@ Upgrading Using the ISO
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 To perform an upgrade using this method,
-`download <http://download.freenas.org/latest/>`_
+`download <http://download.freenas.org/latest/>`__
 the :file:`.iso` to the computer that will be used to prepare the
 installation media. Burn the downloaded :file:`.iso` file to a CD or
 USB thumb drive using the instructions in
@@ -747,10 +747,10 @@ Virtualization
 %brand% can be run inside a virtual environment for development,
 experimentation, and educational purposes. Please note that running
 %brand% in production as a virtual machine is `not recommended
-<https://forums.freenas.org/index.php?threads/please-do-not-run-freenas-in-production-as-a-virtual-machine.12484/>`_.
+<https://forums.freenas.org/index.php?threads/please-do-not-run-freenas-in-production-as-a-virtual-machine.12484/>`__.
 If you decide to use %brand% within a virtual environment,
 `read this post first
-<https://forums.freenas.org/index.php?threads/absolutely-must-virtualize-freenas-a-guide-to-not-completely-losing-your-data.12714/>`_
+<https://forums.freenas.org/index.php?threads/absolutely-must-virtualize-freenas-a-guide-to-not-completely-losing-your-data.12714/>`__
 as it contains useful guidelines for minimizing the risk of losing
 data.
 
@@ -776,7 +776,7 @@ within VirtualBox and VMware ESXi environments.
 VirtualBox
 ~~~~~~~~~~
 
-`VirtualBox <https://www.virtualbox.org/>`__
+`VirtualBox <https://www.virtualbox.org/>`___
 is an open source virtualization program originally created by Sun
 Microsystems. VirtualBox runs on Windows, BSD, Linux, Macintosh, and
 OpenSolaris. It can be configured to use a downloaded %brand%
@@ -984,14 +984,14 @@ VMware ESXi
 ~~~~~~~~~~~
 
 Before using ESXi, read `this post
-<https://forums.freenas.org/index.php?threads/sync-writes-or-why-is-my-esxi-nfs-so-slow-and-why-is-iscsi-faster.12506/>`_
+<https://forums.freenas.org/index.php?threads/sync-writes-or-why-is-my-esxi-nfs-so-slow-and-why-is-iscsi-faster.12506/>`__
 for an explanation of why iSCSI will be faster than NFS.
 
 ESXi is a bare-metal hypervisor architecture created by VMware Inc.
 Commercial and free versions of the VMware vSphere Hypervisor
 operating system (ESXi) are available from the
 `VMware website
-<http://www.vmware.com/products/esxi-and-esx/overview>`_.
+<https://www.vmware.com/products/esxi-and-esx.html>`__.
 After the operating system is installed on supported hardware, use a
 web browser to connect to its IP address. The welcome screen provides
 a link to download the VMware vSphere client which is used to create

--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -10,7 +10,7 @@ system.
 Version |release|
 
 Copyright © 2011-2018
-`iXsystems <https://www.ixsystems.com/>`_
+`iXsystems <https://www.ixsystems.com/>`__
 
 
 .. raw:: latex
@@ -149,7 +149,7 @@ These base applications and drivers have been updated or added:
 * `s3cmd <http://s3tools.org/s3cmd>`__
   has been added back as a CLI alternative to :ref:`S3`.
 
-* The `zfs-stats <http://www.vx.sk/zfs-stats/>`_
+* The `zfs-stats <http://www.vx.sk/zfs-stats/>`__
   CLI utility has been added. Type :command:`zfs-stats` to see command
   usage.
 
@@ -359,15 +359,15 @@ U2
   :ref:`Create Dataset` and :ref:`Create zvol`.
 
 * Midnight Commander has been updated to version
-  `4.8.20 <http://midnight-commander.org/wiki/NEWS-4.8.20>`_.
+  `4.8.20 <http://midnight-commander.org/wiki/NEWS-4.8.20>`__.
 
 U3
 ~~
 
 * Samba has been patched to address
-  `CVE-2018-1050 <https://www.samba.org/samba/security/CVE-2018-1050.html>`_
+  `CVE-2018-1050 <https://www.samba.org/samba/security/CVE-2018-1050.html>`__
   and
-  `CVE-2018-1057 <https://wiki.samba.org/index.php/CVE-2018-1057>`_.
+  `CVE-2018-1057 <https://wiki.samba.org/index.php/CVE-2018-1057>`__.
 
 
 .. index:: Path and Name Lengths
@@ -388,10 +388,10 @@ Hardware Recommendations
 %brand% |release| is based on FreeBSD 11.1 and supports the same
 hardware found in the
 `FreeBSD Hardware Compatibility List
-<http://www.freebsd.org/releases/11.1R/hardware.html>`__.
+<https://www.freebsd.org/releases/11.1R/hardware.html>`__.
 Supported processors are listed in section
 `2.1 amd64
-<https://www.freebsd.org/releases/11.1R/hardware.html#proc>`_.
+<https://www.freebsd.org/releases/11.1R/hardware.html#proc>`__.
 %brand% is only available for 64-bit processors. This architecture is
 called *amd64* by AMD and *Intel 64* by Intel.
 
@@ -402,7 +402,7 @@ called *amd64* by AMD and *Intel 64* by Intel.
 Actual hardware requirements vary depending on the usage of the
 %brand% system. This section provides some starter guidelines. The
 `FreeNAS® Hardware Forum
-<https://forums.freenas.org/index.php?forums/hardware.18/>`_
+<https://forums.freenas.org/index.php?forums/hardware.18/>`__
 has performance tips from %brand% users and is a place to post
 questions regarding the hardware best suited to meet specific
 requirements.
@@ -410,10 +410,10 @@ requirements.
 <https://forums.freenas.org/index.php?resources/hardware-recommendations-guide.12/>`__
 gives detailed recommendations for system components, with the
 `FreeNAS® Quick Hardware Guide
-<https://forums.freenas.org/index.php?resources/freenas-quick-hardware-guide.7>`__
+<https://forums.freenas.org/index.php?resources/freenas%C2%AE-quick-hardware-guide.7/>`__
 providing short lists of components for various configurations.
 `Building, Burn-In, and Testing your FreeNAS® system
-<https://forums.freenas.org/index.php?threads/building-burn-in-and-testing-your-freenas-system.17750/>`_
+<https://forums.freenas.org/index.php?threads/building-burn-in-and-testing-your-freenas-system.17750/>`__
 has detailed instructions on testing new hardware.
 
 
@@ -471,7 +471,7 @@ thus providing consistency for the checksumming and parity
 calculations performed by ZFS. If your data is important, use ECC RAM.
 This
 `Case Study
-<http://research.cs.wisc.edu/adsl/Publications/zfs-corruption-fast10.pdf>`_
+<http://research.cs.wisc.edu/adsl/Publications/zfs-corruption-fast10.pdf>`__
 describes the risks associated with memory corruption.
 
 Do not use %brand% to store data without at least 8 GB of RAM. Many
@@ -545,7 +545,7 @@ Storage Disks and Controllers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `Disk section
-<http://www.freebsd.org/releases/11.1R/hardware.html#DISK>`_
+<https://www.freebsd.org/releases/11.1R/hardware.html#disk>`__
 of the FreeBSD Hardware List lists the supported disk controllers. In
 addition, support for 3ware 6 Gbps RAID controllers has been added
 along with the CLI utility :command:`tw_cli` for managing 3ware RAID
@@ -585,7 +585,7 @@ Suggestions for testing disks before adding them to a RAID array can
 be found in this
 `forum post
 <https://forums.freenas.org/index.php?threads/checking-new-hdds-in-raid.12082/#post-55936>`__.
-Additionally, `badblocks <https://linux.die.net/man/8/badblocks>`_ is
+Additionally, `badblocks <https://linux.die.net/man/8/badblocks>`__ is
 installed with %brand% for testing disks.
 
 If the budget allows optimization of the disk subsystem, consider the
@@ -599,7 +599,7 @@ read/write needs and RAID requirements:
 
 For ZFS,
 `Disk Space Requirements for ZFS Storage Pools
-<http://docs.oracle.com/cd/E19253-01/819-5461/6n7ht6r12/index.html>`_
+<https://docs.oracle.com/cd/E19253-01/819-5461/6n7ht6r12/index.html>`__
 recommends a minimum of 16 GB of disk space. Due to the way that ZFS
 creates swap,
 **it is not possible to format less than 3 GB of space with ZFS**.
@@ -609,7 +609,7 @@ drive, 2 GB will be reserved for swap.
 
 Users new to ZFS who are purchasing hardware should read through
 `ZFS Storage Pools Recommendations
-<https://web.archive.org/web/20161028084224/http://www.solarisinternals.com/wiki/index.php/ZFS_Best_Practices_Guide#ZFS_Storage_Pools_Recommendations>`_
+<https://web.archive.org/web/20161028084224/http://www.solarisinternals.com/wiki/index.php/ZFS_Best_Practices_Guide#ZFS_Storage_Pools_Recommendations>`__
 first.
 
 ZFS *vdevs*, groups of disks that act like a single device, can be
@@ -622,7 +622,7 @@ performance.
 
 The
 `ZFS Drive Size and Cost Comparison spreadsheet
-<https://forums.freenas.org/index.php?threads/zfs-drive-size-and-cost-comparison-spreadsheet.38092/>`_
+<https://forums.freenas.org/index.php?threads/zfs-drive-size-and-cost-comparison-spreadsheet.38092/>`__
 is available to compare usable space provided by different quantities
 and sizes of disks.
 
@@ -633,7 +633,7 @@ Network Interfaces
 ~~~~~~~~~~~~~~~~~~
 
 The `Ethernet section
-<http://www.freebsd.org/releases/11.1R/hardware.html#ethernet>`_
+<https://www.freebsd.org/releases/11.1R/hardware.html#ethernet>`__
 of the FreeBSD Hardware Notes indicates which interfaces are supported
 by each driver. While many interfaces are supported, %brand% users
 have seen the best performance from Intel and Chelsio interfaces, so
@@ -662,12 +662,12 @@ for more information.
 Both hardware and the type of shares can affect network performance.
 On the same hardware, SMB is slower than FTP or NFS because Samba is
 `single-threaded
-<https://www.samba.org/samba/docs/man/Samba-Developers-Guide/architecture.html>`__.
+<https://www.samba.org/samba/docs/old/Samba3-Developers-Guide/architecture.html>`__.
 So a fast CPU can help with SMB performance.
 
 Wake on LAN (WOL) support depends on the FreeBSD driver for the
 interface. If the driver supports WOL, it can be enabled using
-`ifconfig(8) <http://www.freebsd.org/cgi/man.cgi?query=ifconfig>`_. To
+`ifconfig(8) <https://www.freebsd.org/cgi/man.cgi?query=ifconfig>`__. To
 determine if WOL is supported on a particular interface, use the
 interface name with the following command. In this example, the
 capabilities line indicates that WOL is supported for the *re0*

--- a/userguide/jails.rst
+++ b/userguide/jails.rst
@@ -33,7 +33,7 @@ jails as needed and to customize the operating system and installed
 software within each jail.
 
 By default, a
-`FreeBSD jail <https://en.wikipedia.org/wiki/Freebsd_jail>`_
+`FreeBSD jail <https://en.wikipedia.org/wiki/Freebsd_jail>`__
 is created. This provides a very light-weight, operating system-level
 virtualization. Consider it as another independent instance of FreeBSD
 running on the same hardware, without all of the overhead usually
@@ -359,7 +359,7 @@ display these settings by checking the box
 
 
 .. note:: The IPv4 and IPv6 bridge interface is used to bridge the
-   `epair(4) <http://www.freebsd.org/cgi/man.cgi?query=epair>`_
+   `epair(4) <https://www.freebsd.org/cgi/man.cgi?query=epair>`__
    device, which is automatically created for each started jail, to a
    physical network device. The default network device is the one that
    is configured with a default gateway. So, if *em0* is the FreeBSD
@@ -454,7 +454,7 @@ storage as described in :ref:`Add Storage`.
 
 **Upload Plugin:** manually upload a plugin previously downloaded from
 the
-`plugins repository <http://download.freenas.org/plugins/9/x64/>`_.
+`plugins repository <http://download.freenas.org/plugins/9/x64/>`__.
 
 **Start/Stop:** this icon changes appearance depending on the current
 :guilabel:`Status` of the jail. When the jail is not running, the icon
@@ -550,7 +550,7 @@ large amount of data or if an application in a jail needs access to
 the data stored on the %brand% system. One example is transmission,
 which stores torrents. The storage is added using the
 `mount_nullfs(8)
-<http://www.freebsd.org/cgi/man.cgi?query=mount_nullfs>`_
+<https://www.freebsd.org/cgi/man.cgi?query=mount_nullfs>`__
 mechanism, which links data that resides outside of the jail as a
 storage area within the jail.
 
@@ -697,7 +697,7 @@ software to run on a FreeBSD system.
 A huge amount of software has been ported to FreeBSD, currently over
 24,000 applications, and most of that software is available as a
 package. One way to find FreeBSD software is to use the search bar at
-`FreshPorts.org <http://www.freshports.org/>`_.
+`FreshPorts.org <https://www.freshports.org/>`__.
 
 After finding the name of the desired package, use the
 :command:`pkg install` command to install it. For example, to install
@@ -805,7 +805,7 @@ Compiling a port has these disadvantages:
    :command:`pkg install` command instead.
 
 The
-`FreshPorts.org <http://www.freshports.org/>`_
+`FreshPorts.org <https://www.freshports.org/>`__
 listing shows whether a port has any configurable compile options.
 :numref:`Figure %s <config_opts_audiotag_fig>`
 shows the :guilabel:`Configuration Options` for audiotag.
@@ -1123,7 +1123,7 @@ Using iocage
 ------------
 
 Beginning with %brand% 9.10.1, the
-`iocage <https://github.com/iocage/iocage>`_
+`iocage <https://github.com/iocage/iocage>`__
 command line utility is included for creating and managing jails. Click
 the :guilabel:`Shell` option to open the command line and begin using
 iocage.
@@ -1152,7 +1152,7 @@ Iocage has several options to help users:
 * The iocage manual page is accessed by typing :samp:`man iocage`.
 
 * The iocage project also has documentation available on
-  `readthedocs.io <http://iocage.readthedocs.io/en/latest/index.html>`_.
+  `readthedocs.io <http://iocage.readthedocs.io/en/latest/index.html>`__.
 
 
 Managing iocage Jails

--- a/userguide/network.rst
+++ b/userguide/network.rst
@@ -703,7 +703,7 @@ The configurable options are summarized in
    |                      |                |                                                                                                |
    +----------------------+----------------+------------------------------------------------------------------------------------------------+
    | Options              | string         | Additional parameters from                                                                     |
-   |                      |                | `ifconfig(8) <http://www.freebsd.org/cgi/man.cgi?query=ifconfig>`__.                           |
+   |                      |                | `ifconfig(8) <https://www.freebsd.org/cgi/man.cgi?query=ifconfig>`__.                          |
    |                      |                |                                                                                                |
    +----------------------+----------------+------------------------------------------------------------------------------------------------+
 
@@ -742,7 +742,7 @@ Link aggregation load balancing can be tested with:
 
 
 More information about this command can be found at
-`systat(1) <http://www.freebsd.org/cgi/man.cgi?query=systat>`__.
+`systat(1) <https://www.freebsd.org/cgi/man.cgi?query=systat>`__.
 
 
 .. _Network Summary:

--- a/userguide/plugins.rst
+++ b/userguide/plugins.rst
@@ -7,10 +7,10 @@ Plugins
 %brand% 8.2.0 introduced the ability to extend the built-in NAS
 services by providing a mechanism for installing additional software.
 This mechanism was known as the Plugins architecture and is based on
-`FreeBSD jails <https://en.wikipedia.org/wiki/Freebsd_jail>`_
+`FreeBSD jails <https://en.wikipedia.org/wiki/Freebsd_jail>`__
 and
 `PC-BSD 9.x PBIs
-<http://wiki.pcbsd.org/index.php/AppCafe%C2%AE/9.2>`_.
+<http://wiki.pcbsd.org/index.php/AppCafe%C2%AE/9.2>`__.
 This allowed
 users to install and configure additional applications once they had
 created and configured a plugins jail.
@@ -256,59 +256,59 @@ Available Plugins
 
 These plugins are available for %brand% |release|:
 
-* `bacula-sd (storage daemon) <http://bacula.org/>`_
+* `bacula-sd (storage daemon) <http://blog.bacula.org/>`__
 
-* `CouchPotato <https://couchpota.to/>`_
+* `CouchPotato <https://couchpota.to/>`__
 
-* `crashplan <http://www.code42.com/crashplan/>`_
+* `crashplan <https://www.crashplan.com/en-us/>`__
 
-* `Emby <http://emby.media/>`_
+* `Emby <https://emby.media/>`__
 
-* `firefly <https://en.wikipedia.org/wiki/Firefly_Media_Server>`_
+* `firefly <https://en.wikipedia.org/wiki/Firefly_Media_Server>`__
 
-* `Headphones <https://github.com/rembo10/headphones>`_
+* `Headphones <https://github.com/rembo10/headphones>`__
 
-* `HTPC-Manager <http://htpc.io/>`_
+* `HTPC-Manager <http://htpc.io/>`__
 
-* `LazyLibrarian <https://github.com/lazylibrarian/LazyLibrarian>`_
+* `LazyLibrarian <https://github.com/lazylibrarian/LazyLibrarian>`__
 
-* `Madsonic <http://madsonic.org/>`_
+* `Madsonic <http://beta.madsonic.org/pages/index.jsp>`__
 
-* `Maraschino <http://www.maraschinoproject.com/>`_
+* `Maraschino <http://www.maraschinoproject.com/>`__
 
-* `MineOS <http://minecraft.codeemo.com/>`_
+* `MineOS <http://minecraft.codeemo.com/>`__
 
-* `Mylar <https://github.com/evilhero/mylar>`_
+* `Mylar <https://github.com/evilhero/mylar>`__
 
-* `Nextcloud <https://nextcloud.com/>`_
+* `Nextcloud <https://nextcloud.com/>`__
 
-* `NZBHydra <https://github.com/theotherp/nzbhydra>`_
+* `NZBHydra <https://github.com/theotherp/nzbhydra>`__
 
-* `ownCloud <https://owncloud.org/>`_
+* `ownCloud <https://owncloud.org/>`__
 
-* `PlexMediaServer <https://plex.tv/>`_
+* `PlexMediaServer <https://www.plex.tv/>`__
 
-* `Resilio <https://www.resilio.com/>`_
+* `Resilio <https://www.resilio.com/>`__
 
-* `s3cmd <http://s3tools.org/s3cmd>`_
+* `s3cmd <http://s3tools.org/s3cmd>`__
 
-* `SABnzbd <http://sabnzbd.org/>`_
+* `SABnzbd <https://sabnzbd.org/>`__
 
-* `SickBeard <http://sickbeard.com/>`_
+* `SickBeard <http://sickbeard.com/>`__
 
-* `SickRage <https://github.com/SiCKRAGETV/SickRage>`_
+* `SickRage <https://github.com/SiCKRAGETV/SickRage>`__
 
-* `Sonarr <https://sonarr.tv/>`_
+* `Sonarr <https://sonarr.tv/>`__
 
-* `Subsonic <http://www.subsonic.org/pages/index.jsp>`_
+* `Subsonic <http://www.subsonic.org/pages/index.jsp>`__
 
-* `Syncthing <https://syncthing.net/>`_
+* `Syncthing <https://syncthing.net/>`__
 
-* `Transmission <http://www.transmissionbt.com/>`_
+* `Transmission <https://transmissionbt.com/>`__
 
-* `XDM <https://github.com/lad1337/XDM>`_
+* `XDM <https://github.com/lad1337/XDM>`__
 
-* `XMRig <https://github.com/xmrig/xmrig>`_
+* `XMRig <https://github.com/xmrig/xmrig>`__
 
 While the %brand% Plugins system makes it easy to install software,
 it is still up to you to know how to configure and use the installed

--- a/userguide/processes.rst
+++ b/userguide/processes.rst
@@ -5,7 +5,7 @@ Display System Processes
 
 Clicking :guilabel:`Display System Processes` opens a screen showing
 the output of
-`top(1) <http://www.freebsd.org/cgi/man.cgi?query=top>`_.
+`top(1) <https://www.freebsd.org/cgi/man.cgi?query=top>`__.
 An example is shown in
 :numref:`Figure %s <system_processes_fig>`.
 

--- a/userguide/quick.rst
+++ b/userguide/quick.rst
@@ -111,7 +111,7 @@ entered in a browser:
   missing menu items, try a different web browser. IE9 has known
   issues and does not display the graphical administrative interface
   correctly if compatibility mode is turned on.
-  `Firefox <https://www.mozilla.org/en-US/firefox/all/>`_ is
+  `Firefox <https://www.mozilla.org/en-US/firefox/all/>`__ is
   recommended.
 
 * If :guilabel:`An error occurred!` messages are shown when attempting
@@ -119,7 +119,7 @@ entered in a browser:
   to allow cookies from the %brand% system.
 
 This `blog post
-<http://fortysomethinggeek.blogspot.com/2012/10/ipad-iphone-connect-with-freenas-or-any.html>`_
+<http://fortysomethinggeek.blogspot.com/2012/10/ipad-iphone-connect-with-freenas-or-any.html>`__
 describes some applications which can be used to access the %brand%
 system from an iPad or iPhone.
 

--- a/userguide/reporting.rst
+++ b/userguide/reporting.rst
@@ -102,6 +102,6 @@ or monthly. The :guilabel:`<<` and :guilabel:`>>` buttons can be
 used to scroll through the output.
 
 `Update on using Graphite with FreeNAS
-<http://cmhramblings.blogspot.com/2015/12/update-on-using-graphite-with-freenas.html>`_
+<http://cmhramblings.blogspot.com/2015/12/update-on-using-graphite-with-freenas.html>`__
 contains instructions for sending the collected information to a
-`Graphite <http://graphite.wikidot.com/>`__ server.
+`Graphite <http://graphiteapp.org/>`__ server.

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1779,7 +1779,7 @@ display these settings by checking the box
    |                               |                |          |                                                                                                     |
    +-------------------------------+----------------+----------+-----------------------------------------------------------------------------------------------------+
    | Extra Options                 | string         | ✓        | Additional                                                                                          |
-   |                               |                |          | `sshd_config(5) <http://www.freebsd.org/cgi/man.cgi?query=sshd_config>`__                           |
+   |                               |                |          | `sshd_config(5) <https://www.freebsd.org/cgi/man.cgi?query=sshd_config>`__                          |
    |                               |                |          | options not covered in this screen, one per line. These options are case-sensitive                  |
    |                               |                |          | and misspellings can prevent the SSH service from starting.                                         |
    |                               |                |          |                                                                                                     |

--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -48,7 +48,7 @@ These types of shares and services are available:
 
 * :ref:`WebDAV <WebDAV Shares>`: WebDAV shares are accessible using an
   authenticated web browser (read-only) or
-  `WebDAV client <https://en.wikipedia.org/wiki/WebDAV#Clients>`_
+  `WebDAV client <https://en.wikipedia.org/wiki/WebDAV#Client_support>`__
   running on any operating system.
 
 * :ref:`SMB <Windows (SMB) Shares>`: Server Message Block shares, also
@@ -67,12 +67,12 @@ These types of shares and services are available:
 Fast access from any operating system can be obtained by configuring
 the :ref:`FTP` service instead of a share and using a cross-platform
 FTP file manager application such as
-`Filezilla <https://filezilla-project.org/>`_.
+`Filezilla <https://filezilla-project.org/>`__.
 Secure FTP can be configured if the data needs to be encrypted.
 
 When data security is a concern and the network users are familiar
 with SSH command line utilities or
-`WinSCP <http://winscp.net/eng/index.php>`_,
+`WinSCP <https://winscp.net/eng/index.php>`__,
 consider using the :ref:`SSH` service instead of a share. It is slower
 than unencrypted FTP due to the encryption overhead, but the data
 passing through the network is encrypted.
@@ -106,7 +106,7 @@ Apple (AFP) Shares
 ------------------
 
 %brand% uses the
-`Netatalk <http://netatalk.sourceforge.net/>`_
+`Netatalk <http://netatalk.sourceforge.net/>`__
 AFP server to share data with Apple systems. This section describes
 the configuration screen for fine-tuning AFP shares created using the
 :ref:`Wizard`. It then provides configuration examples for using the
@@ -138,7 +138,7 @@ information given when the share was created.
    advanced option without fully understanding the function of that
    option. Refer to
    `Setting up Netatalk
-   <http://netatalk.sourceforge.net/2.2/htmldocs/configuration.html>`_
+   <http://netatalk.sourceforge.net/2.2/htmldocs/configuration.html>`__
    for a more detailed explanation of these options.
 
 
@@ -219,7 +219,7 @@ information given when the share was created.
    | Hosts Deny                   | string        |  ✓       | Comma-, space-, or tab-delimited list of denied hostnames or IP addresses.                                    |
    |                              |               |          |                                                                                                               |
    +------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------------+
-   | Auxiliary Parameters         | string        |          | Additional `afp.conf <http://netatalk.sourceforge.net/3.1/htmldocs/afp.conf.5.html>`_ parameters              |
+   | Auxiliary Parameters         | string        |          | Additional `afp.conf <http://netatalk.sourceforge.net/3.1/htmldocs/afp.conf.5.html>`__ parameters             |
    |                              |               |          | not covered by other option fields.                                                                           |
    |                              |               |          |                                                                                                               |
    +------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------------+
@@ -418,7 +418,7 @@ Time Machine share is restricted to 200 GB.
 .. note:: An alternative is to create a global quota using the
    instructions in
    `Set up Time Machine for multiple machines with OSX Server-Style Quotas
-   <https://forums.freenas.org/index.php?threads/how-to-set-up-time-machine-for-multiple-machines-with-osx-server-style-quotas.47173/>`_.
+   <https://forums.freenas.org/index.php?threads/how-to-set-up-time-machine-for-multiple-machines-with-osx-server-style-quotas.47173/>`__.
 
 To configure Time Machine on the macOS client, go to
 :menuselection:`System Preferences --> Time Machine`
@@ -444,13 +444,13 @@ backup disk image could not be created (error 45)` is shown when
 backing up to the %brand% system, a sparsebundle
 image must be created using
 `these instructions
-<http://forum1.netgear.com/showthread.php?t=49482>`_.
+<https://community.netgear.com/t5/Stora-Legacy/Solution-to-quot-Time-Machine-could-not-complete-the-backup/td-p/294697>`__.
 
 If :guilabel:`Time Machine completed a verification of
 your backups. To improve reliability, Time Machine must create a new
 backup for you.` is shown, follow the instructions in
 `this post
-<http://www.garth.org/archives/2011,08,27,169,fix-time-machine-sparsebundle-nas-based-backup-errors.html>`_
+<http://www.garth.org/archives/2011,08,27,169,fix-time-machine-sparsebundle-nas-based-backup-errors.html>`__
 to avoid making another backup or losing past backups.
 
 
@@ -473,7 +473,7 @@ application.
    when %brand% is installed on ESXi. When considering creating NFS
    shares on ESXi, read through the performance analysis at
    `Running ZFS over NFS as a VMware Store
-   <http://blog.laspina.ca/ubiquitous/running-zfs-over-nfs-as-a-vmware-store>`_.
+   <http://blog.laspina.ca/ubiquitous/running-zfs-over-nfs-as-a-vmware-store>`__.
 #endif freenas
 
 To create an NFS share using the :ref:`Wizard`, click the
@@ -554,7 +554,7 @@ button.
    |                     |                |          |                                                                                                            |
    +---------------------+----------------+----------+------------------------------------------------------------------------------------------------------------+
    | Quiet               | checkbox       | ✓        | Inhibit otherwise-useful syslog diagnostics to avoid some annoying error messages. See                     |
-   |                     |                |          | `exports(5) <http://www.freebsd.org/cgi/man.cgi?query=exports>`_ for examples.                             |
+   |                     |                |          | `exports(5) <https://www.freebsd.org/cgi/man.cgi?query=exports>`__ for examples.                           |
    |                     |                |          |                                                                                                            |
    +---------------------+----------------+----------+------------------------------------------------------------------------------------------------------------+
    | Maproot User        | drop-down menu | ✓        | When a user is selected, the *root* user is limited to that user's permissions.                            |
@@ -725,7 +725,7 @@ A successful mounting of the share returns to the command prompt
 without any status or error messages.
 
 .. note:: If this command fails on a Linux system, make sure that the
-   `nfs-utils <http://sourceforge.net/projects/nfs/files/nfs-utils/>`_
+   `nfs-utils <https://sourceforge.net/projects/nfs/files/nfs-utils/>`__
    package is installed.
 
 
@@ -944,7 +944,7 @@ share. These settings are described in :ref:`WebDAV`.
 Windows (SMB) Shares
 ---------------------
 
-%brand% uses `Samba <https://www.samba.org/>`_ to share volumes using
+%brand% uses `Samba <https://www.samba.org/>`__ to share volumes using
 Microsoft's SMB protocol. SMB is built into the Windows and macOS
 operating systems and most Linux and BSD systems pre-install the Samba
 client in order to provide support for SMB. If the distro did not,
@@ -963,7 +963,7 @@ clients from Windows 8 and higher. Copying between two different
 shares is not server-side. Windows 7 clients support server-side
 copying with
 `Robocopy
-<https://technet.microsoft.com/en-us/library/cc733145>`_.
+<https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/cc733145(v=ws.11)>`__.
 
 This chapter starts by summarizing the available configuration
 options. It demonstrates some common configuration scenarios as well
@@ -976,14 +976,14 @@ scenario that meets your specific network requirements.
    <https://forums.freenas.org/index.php?resources/smb-tips-and-tricks.15/>`__
    shows helpful hints for configuring and managing SMB networking.
    The `FreeNAS and Samba (CIFS) permissions
-   <https://www.youtube.com/watch?v=RxggaE935PM>`_
+   <https://www.youtube.com/watch?v=RxggaE935PM>`__
    and
    `Advanced Samba (CIFS) permissions on FreeNAS
-   <https://www.youtube.com/watch?v=QhwOyLtArw0>`_
+   <https://www.youtube.com/watch?v=QhwOyLtArw0>`__
    videos clarify setting up permissions on SMB shares. Another
    helpful reference is
    `Methods For Fine-Tuning Samba Permissions
-   <https://forums.freenas.org/index.php?threads/methods-for-fine-tuning-samba-permissions.50739/>`_.
+   <https://forums.freenas.org/index.php?threads/methods-for-fine-tuning-samba-permissions.50739/>`__.
 
 
 .. tip:: Run :command:`smbstatus` from the :ref:`Shell` for a list of
@@ -1011,7 +1011,7 @@ not needed. For more complex sharing scenarios, only change an
 :guilabel:`Advanced Mode` option after fully understanding the
 function of that option.
 `smb.conf(5)
-<https://www.freebsd.org/cgi/man.cgi?query=smb.conf&manpath=FreeBSD+11.0-RELEASE+and+Ports>`_
+<https://www.freebsd.org/cgi/man.cgi?query=smb.conf&manpath=FreeBSD+11.0-RELEASE+and+Ports>`__
 provides more details for each configurable option.
 
 
@@ -1124,7 +1124,7 @@ Samba disables NTLMv1 authentication by default for security. Standard
 configurations of Windows XP and some configurations of later clients
 like Windows 7 will not be able to connect with NTLMv1 disabled.
 `Security guidance for NTLMv1 and LM network authentication
-<https://support.microsoft.com/en-us/help/2793313/security-guidance-for-ntlmv1-and-lm-network-authentication>`_
+<https://support.microsoft.com/en-us/help/2793313/security-guidance-for-ntlmv1-and-lm-network-authentication>`__
 has information about the security implications and ways to enable
 NTLMv2 on those clients. If changing the client configuration is not
 possible, NTLMv1 authentication can be enabled by checking the box
@@ -1139,9 +1139,9 @@ each module **before** adding or deleting it from the
 the share. Some modules need additional configuration after they are
 added. Refer to
 `Stackable VFS modules
-<https://www.samba.org/samba/docs/man/Samba-HOWTO-Collection/VFS.html>`_
+<https://www.samba.org/samba/docs/old/Samba3-HOWTO/VFS.html>`__
 and the
-`vfs_* man pages <https://www.samba.org/samba/docs/man/manpages/>`_
+`vfs_* man pages <https://www.samba.org/samba/docs/current/man-html/>`__
 for more details.
 
 
@@ -1260,7 +1260,7 @@ for more details.
    |                     |                                                                                                                                            |
    +---------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
    | streams_depot       | **Experimental** module to store alternate data streams in a central directory; the association with the primary file can be lost due      |
-   |                     | to inode numbers changing when a directory is copied to a new location (see `<http://marc.info/?l=samba&m=132542069802160&w=2>`_).         |
+   |                     | to inode numbers changing when a directory is copied to a new location (see `<https://marc.info/?l=samba&m=132542069802160&w=2>`__).       |
    +---------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
    | streams_xattr       | Enables storing of NTFS alternate data streams in the file system.                                                                         |
    |                     |                                                                                                                                            |
@@ -1521,14 +1521,14 @@ prompt to authenticate will occur.
 Configuring Shadow Copies
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`Shadow Copies <https://en.wikipedia.org/wiki/Shadow_copy>`_,
+`Shadow Copies <https://en.wikipedia.org/wiki/Shadow_copy>`__,
 also known as the Volume Shadow Copy Service (VSS) or Previous
 Versions, is a Microsoft service for creating volume snapshots. Shadow
 copies can be used to restore previous versions of files from
 within Windows Explorer. Shadow Copy support is built into Vista and
 Windows 7. Windows XP or 2000 users need to install the
 `Shadow Copy client
-<http://www.microsoft.com/en-us/download/details.aspx?displaylang=en&id=16220>`_.
+<http://www.microsoft.com/en-us/download/details.aspx?displaylang=en&id=16220>`__.
 
 When a periodic snapshot task is created on a ZFS volume that is
 configured as a SMB share in %brand%, it is automatically configured
@@ -1709,7 +1709,7 @@ automatically switch back to that better path to the storage.
 In %brand%, iSCSI is built into the kernel. This version of iSCSI
 supports
 `Microsoft Offloaded Data Transfer (ODX)
-<https://technet.microsoft.com/en-us/library/hh831628>`_,
+<https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/hh831628(v=ws.11)>`__,
 meaning that file copies happen locally, rather than over the network.
 It also supports the :ref:`VAAI` (vStorage APIs for Array Integration)
 primitives for efficient operation of storage tasks directly on the
@@ -1816,7 +1816,7 @@ for iSNS requests is 5 seconds.
    +---------------------------------+------------------------------+-------------------------------------------------------------------------------------------+
 #ifdef truenas
    | Enable iSCSI ALUA               | checkbox                     | Enable ALUA for automatic best path discovery when supported by clients. This option      |
-   |                                 |                              | is only available on HA systems.                                                           |
+   |                                 |                              | is only available on HA systems.                                                          |
    +---------------------------------+------------------------------+-------------------------------------------------------------------------------------------+
 #endif truenas
 
@@ -2145,7 +2145,7 @@ There are two types of extents: *device* and *file*.
 snapshots, or physical devices like a disk, an SSD, a hardware RAID
 volume, or a
 `HAST device
-<http://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/disks-hast.html>`_.
+<https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/disks-hast.html>`__.
 
 **File extents** provide virtual storage access to an individual file.
 
@@ -2483,34 +2483,33 @@ To access the iSCSI target, clients must use iSCSI initiator software.
 
 An iSCSI Initiator client is pre-installed with Windows 7. A detailed
 how-to for this client can be found
-`here
-<http://www.windowsnetworking.com/articles-tutorials/windows-7/Connecting-Windows-7-iSCSI-SAN.html>`__.
+`here <http://techgenix.com/Connecting-Windows-7-iSCSI-SAN/>`__.
 A client for Windows 2000, XP, and 2003 can be found `here
 <http://www.microsoft.com/en-us/download/details.aspx?id=18986>`__.
 This
 `how-to
-<http://blog.pluralsight.com/freenas-8-iscsi-target-windows-7>`_
+<https://www.pluralsight.com/blog/software-development/freenas-8-iscsi-target-windows-7>`__
 shows how to create an iSCSI target for a Windows 7 system.
 
 Mac OS X does not include an initiator.
 `globalSAN
-<http://www.studionetworksolutions.com/globalsan-iscsi-initiator/>`_
+<http://www.studionetworksolutions.com/globalsan-iscsi-initiator/>`__
 is a commercial, easy-to-use Mac initiator.
 
 BSD systems provide command line initiators:
-`iscontrol(8) <http://www.freebsd.org/cgi/man.cgi?query=iscontrol>`_
+`iscontrol(8) <https://www.freebsd.org/cgi/man.cgi?query=iscontrol>`__
 comes with FreeBSD versions 9.x and lower,
-`iscsictl(8) <https://www.freebsd.org/cgi/man.cgi?query=iscsictl>`_
+`iscsictl(8) <https://www.freebsd.org/cgi/man.cgi?query=iscsictl>`__
 comes with FreeBSD versions 10.0 and higher,
 `iscsi-initiator(8)
-<http://netbsd.gw.com/cgi-bin/man-cgi?iscsi-initiator++NetBSD-current>`_
+<http://netbsd.gw.com/cgi-bin/man-cgi?iscsi-initiator++NetBSD-current>`__
 comes with NetBSD, and
 `iscsid(8)
-<http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/./man8/iscsid.8?query=iscsid>`_
+<http://man.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man8/iscsid.8?query=iscsid>`__
 comes with OpenBSD.
 
 Some Linux distros provide the command line utility
-:command:`iscsiadm` from `Open-iSCSI <http://www.open-iscsi.com/>`_.
+:command:`iscsiadm` from `Open-iSCSI <http://www.open-iscsi.com/>`__.
 Use a web search to see if a package exists for your distribution
 should the command not exist on your Linux system.
 
@@ -2523,14 +2522,14 @@ to log into the LUN.
 
 Instructions for connecting from a VMware ESXi Server can be found at
 `How to configure FreeNAS 8 for iSCSI and connect to ESX(i)
-<http://www.vladan.fr/how-to-configure-freenas-8-for-iscsi-and-connect-to-esxi/>`_.
+<https://www.vladan.fr/how-to-configure-freenas-8-for-iscsi-and-connect-to-esxi/>`__.
 Note that the requirements for booting vSphere 4.x off iSCSI differ
 between ESX and ESXi. ESX requires a hardware iSCSI adapter while ESXi
 requires specific iSCSI boot firmware support. The magic is on the
 booting host side, meaning that there is no difference to the %brand%
 configuration. See the
 `iSCSI SAN Configuration Guide
-<http://www.vmware.com/pdf/vsphere4/r41/vsp_41_iscsi_san_cfg.pdf>`_
+<https://www.vmware.com/pdf/vsphere4/r41/vsp_41_iscsi_san_cfg.pdf>`__
 for details.
 
 The VMware firewall only allows iSCSI connections on port 3260 by

--- a/userguide/snippets/alertevents.rst
+++ b/userguide/snippets/alertevents.rst
@@ -89,7 +89,7 @@ Some of the conditions that trigger an alert include:
 
 #ifdef freenas
 * the status of an Avago MegaRAID SAS controller has changed;
-  `mfiutil(8) <http://www.freebsd.org/cgi/man.cgi?query=mfiutil>`_
+  `mfiutil(8) <https://www.freebsd.org/cgi/man.cgi?query=mfiutil>`__
   is included for managing these devices
 #endif freenas
 

--- a/userguide/snippets/unified-storage-array.rst
+++ b/userguide/snippets/unified-storage-array.rst
@@ -216,7 +216,7 @@ network.
 
 The
 `Out-of-Band Management
-<https://support.ixsystems.com/truenasguide/truenas.html#out-of-band-management>`__
+<https://support.ixsystems.com/truenasguide/tn_initial.html#out-of-band-management>`__
 feature requires connection and configuration of the out-of-band
 management port before turning on the %brand% Storage Array. Refer to
 :numref:`Figure %s <appliance11>`
@@ -232,11 +232,11 @@ the out-of-band management port.
 
 
 Storage cabling instructions are shown in the
-`E16/E16F Expansion Shelf
-<https://support.ixsystems.com/truenasguide/tn_hardware.html#e16-e16f-expansion-shelf>`__
+`ES12 Expansion Shelf
+<https://support.ixsystems.com/truenasguide/tn_hardware.html#es12-expansion-shelf>`__
 and
-`E24 Expansion Shelf
-<https://support.ixsystems.com/truenasguide/tn_hardware.html#e24-expansion-shelf>`__
+`ES24 Expansion Shelf
+<https://support.ixsystems.com/truenasguide/tn_hardware.html#es24-expansion-shelf>`__
 setup instructions.
 
 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -104,7 +104,7 @@ summarizes the configuration options of this screen.
    |                  |                |                                                                                            |
    +==================+================+============================================================================================+
    | Volume name      | string         | ZFS volumes must conform to these                                                          |
-   |                  |                | `naming conventions <http://docs.oracle.com/cd/E23824_01/html/821-1448/gbcpt.html>`__;     |
+   |                  |                | `naming conventions <https://docs.oracle.com/cd/E23824_01/html/821-1448/gbcpt.html>`__;    |
    |                  |                | choosing a name that will stick out in the logs (e.g. **not** a generic term like          |
    |                  |                | :file:`data` or :file:`freenas`) is recommended                                            |
    |                  |                |                                                                                            |
@@ -207,7 +207,7 @@ Encryption
 
 
 %brand% supports
-`GELI <http://www.freebsd.org/cgi/man.cgi?query=geli>`_
+`GELI <https://www.freebsd.org/cgi/man.cgi?query=geli>`__
 full disk encryption for ZFS volumes. It is important to understand
 the details when considering whether encryption is right for your
 %brand% system:
@@ -281,7 +281,7 @@ such volumes before using them in production.
 
 #ifdef freenas
 .. note:: Processors with support for the
-   `AES-NI <https://en.wikipedia.org/wiki/AES-NI#Supporting_CPUs>`__
+   `AES-NI <https://en.wikipedia.org/wiki/AES_instruction_set#Supporting_x86_CPUs>`__
    instruction set are strongly recommended. These processors can
    handle encryption of a small number of disks with negligible
    performance impact. They also retain performance better as the
@@ -342,7 +342,7 @@ shows the available options.
    |               |                  |                                                                                                |
    +===============+==================+================================================================================================+
    | Volume name   | string           | ZFS volumes must conform to these                                                              |
-   |               |                  | `naming conventions <http://docs.oracle.com/cd/E19082-01/817-2271/gbcpt/index.html>`__;        |
+   |               |                  | `naming conventions <https://docs.oracle.com/cd/E53394_01/index.html>`__;                      |
    |               |                  | choose a name that will stand out in the logs (e.g. **not** :file:`data` or :file:`freenas`)   |
    |               |                  |                                                                                                |
    +---------------+------------------+------------------------------------------------------------------------------------------------+
@@ -735,7 +735,7 @@ system does not have the needed RAM, it will panic. The only solution
 is to add more RAM or recreate the pool.
 **Think carefully before enabling dedup!**
 This `article
-<http://constantin.glez.de/blog/2011/07/zfs-dedupe-or-not-dedupe>`_
+<https://constantin.glez.de/2011/07/27/zfs-to-dedupe-or-not-dedupe/>`__
 provides a good description of the value versus cost considerations
 for deduplication.
 
@@ -1091,14 +1091,14 @@ configurable options are described in
    |                                    |                |                                                                                                                          |
    +------------------------------------+----------------+--------------------------------------------------------------------------------------------------------------------------+
    | Acoustic Level                     | drop-down menu | default is *Disabled*; can be modified for disks that understand                                                         |
-   |                                    |                | `AAM <https://en.wikipedia.org/wiki/Automatic_acoustic_management>`_                                                     |
+   |                                    |                | `AAM <https://en.wikipedia.org/wiki/Automatic_acoustic_management>`__                                                    |
    |                                    |                |                                                                                                                          |
    +------------------------------------+----------------+--------------------------------------------------------------------------------------------------------------------------+
    | Enable S.M.A.R.T.                  | checkbox       | enabled by default if the disk supports S.M.A.R.T.; unchecking this box will disable any configured                      |
    |                                    |                | :ref:`S.M.A.R.T. Tests` for the disk                                                                                     |
    |                                    |                |                                                                                                                          |
    +------------------------------------+----------------+--------------------------------------------------------------------------------------------------------------------------+
-   | S.M.A.R.T. extra options           | string         | additional `smartctl(8) <https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in>`_  options             |
+   | S.M.A.R.T. extra options           | string         | additional `smartctl(8) <https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in>`__  options            |
    |                                    |                |                                                                                                                          |
    +------------------------------------+----------------+--------------------------------------------------------------------------------------------------------------------------+
 
@@ -1353,7 +1353,7 @@ Encryption applies to a volume, not individual users. When a volume is
 unlocked, data is accessible to all users with permissions to access
 it.
 
-.. note:: `GELI <http://www.freebsd.org/cgi/man.cgi?query=geli>`__
+.. note:: `GELI <https://www.freebsd.org/cgi/man.cgi?query=geli>`__
    uses *two* randomized encryption keys for each disk. The first has
    been discussed here. The second, the disk's "master key", is
    encrypted and stored in the on-disk GELI metadata. Loss of a disk
@@ -1499,9 +1499,9 @@ View Multipaths
 ~~~~~~~~~~~~~~~
 
 %brand% uses
-`gmultipath(8) <http://www.freebsd.org/cgi/man.cgi?query=gmultipath>`_
+`gmultipath(8) <https://www.freebsd.org/cgi/man.cgi?query=gmultipath>`__
 to provide
-`multipath I/O <https://en.wikipedia.org/wiki/Multipath_I/O>`_
+`multipath I/O <https://en.wikipedia.org/wiki/Multipath_I/O>`__
 support on systems containing hardware that is capable of multipath.
 An example would be a dual SAS expander backplane in the chassis or an
 external JBOD.

--- a/userguide/support.rst
+++ b/userguide/support.rst
@@ -41,7 +41,7 @@ main page.
 
 Users are welcome to network on the %brand% social media sites:
 
-* `LinkedIn <http://www.linkedin.com/groups/FreeNAS8-3903140>`__
+* `LinkedIn <https://www.linkedin.com/groups/3903140/profile>`__
 
 * `Google+ <https://plus.google.com/110373675402281849911/posts>`__
 
@@ -51,7 +51,7 @@ Users are welcome to network on the %brand% social media sites:
 * `Facebook FreeNAS Consortium (please request to be added)
   <https://www.facebook.com/groups/1707686686200221>`__
 
-* `Twitter <https://twitter.com/freenasteam>`__
+* `Twitter <https://twitter.com/freenas>`__
 
 
 .. index:: Forums
@@ -128,16 +128,16 @@ IRC
 
 To ask a question in real time, you can use the *#freenas* channel on
 IRC
-`Freenode <http://freenode.net/>`_.
+`Freenode <http://freenode.net/>`__.
 Depending on the time of day and your time zone, %brand% developers or
 other users may be available to provide assistance. If no one answers
 right away, remain on the channel, as other users tend to read the
 channel history to answer questions as time permits.
 
 Typically, an IRC `client
-<http://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients>`_
+<https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients>`__
 is used to access the *#freenas* IRC channel. Alternately, use
-`webchat <http://webchat.freenode.net/?channels=freenas>`_
+`webchat <http://webchat.freenode.net/?channels=freenas>`__
 from a web browser.
 
 To get the most out of the IRC channel, keep these points in mind:
@@ -152,7 +152,7 @@ To get the most out of the IRC channel, keep these points in mind:
   question to be answered.
 
 * Do not post error messages in the channel. Instead, use a pasting
-  service such as `pastebin <http://www.pastebin.com/>`_ and paste the
+  service such as `pastebin <https://pastebin.com/>`__ and paste the
   resulting URL into the IRC discussion.
 
 .. _Videos:
@@ -163,19 +163,19 @@ Videos
 A series of instructional videos are available for %brand%:
 
 * `Install Murmur (Mumble server) on FreeNAS/FreeBSD
-  <https://www.youtube.com/watch?v=aAeZRNfarJc>`_
+  <https://www.youtube.com/watch?v=aAeZRNfarJc>`__
 
 * `FreeNAS® 9.10 - Certificate Authority & SSL Certificates
-  <https://www.youtube.com/watch?v=OT1Le5VQIc0>`_
+  <https://www.youtube.com/watch?v=OT1Le5VQIc0>`__
 
 * `How to Update FreeNAS® 9.10
-  <https://www.youtube.com/watch?v=2nvb90AhgL8>`_
+  <https://www.youtube.com/watch?v=2nvb90AhgL8>`__
 
 * `FreeNAS® 9.10 LAGG & VLAN Overview
-  <https://www.youtube.com/watch?v=wqSH_uQSArQ>`_
+  <https://www.youtube.com/watch?v=wqSH_uQSArQ>`__
 
 * `FreeNAS 9.10 and Samba (SMB) Permissions
-  <https://www.youtube.com/watch?v=RxggaE935PM>`_
+  <https://www.youtube.com/watch?v=RxggaE935PM>`__
 
 * `FreeNAS® 11 - What's New
   <https://www.youtube.com/watch?v=-uJ_7eG88zk>`__
@@ -208,6 +208,6 @@ hours of learning by trial and error. %brand% training classes are
 1-4 hours in length, topic-specific, and provide the information you
 need to quickly get up to speed in %brand% and ZFS. Refer to the
 `FreeNAS® Training and Certification website
-<http://www.freenas.org/freenas-zfs-training/>`_ for more information
+<http://www.freenas.org/freenas-zfs-training/>`__ for more information
 about the courses, pricing, and availability.
 #endif commented

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -164,7 +164,7 @@ can be configured using the General tab:
    | WebGUI HTTP Port     | integer        | allows configuring a non-standard port for accessing the administrative GUI over HTTP; changing this setting             |
    |                      |                | might also require                                                                                                       |
    |                      |                | `changing a Firefox configuration setting                                                                                |
-   |                      |                | <http://www.redbrick.dcu.ie/%7Ed_fens/articles/Firefox:_This_Address_is_Restricted>`_                                    |
+   |                      |                | <https://www.redbrick.dcu.ie/~d_fens/articles/Firefox:_This_Address_is_Restricted>`__                                    |
    +----------------------+----------------+--------------------------------------------------------------------------------------------------------------------------+
    | WebGUI HTTPS Port    | integer        | allows configuring a non-standard port for accessing the administrative GUI over HTTPS                                   |
    |                      |                |                                                                                                                          |
@@ -176,7 +176,7 @@ can be configured using the General tab:
    |                      |                |                                                                                                                          |
    +----------------------+----------------+--------------------------------------------------------------------------------------------------------------------------+
    | Language             | drop-down menu | select the localization from the drop-down menu and reload the browser; view the status of localization at               |
-   |                      |                | `pootle.freenas.org <http://pootle.freenas.org/>`_                                                                       |
+   |                      |                | `weblate.trueos.org <https://weblate.trueos.org/projects/freenas/>`__                                                    |
    |                      |                |                                                                                                                          |
    +----------------------+----------------+--------------------------------------------------------------------------------------------------------------------------+
    | Console Keyboard Map | drop-down menu | select the keyboard layout                                                                                               |
@@ -257,7 +257,7 @@ and the server running the directory service have been configured to
 use the same NTP servers.
 
 Available NTP servers can be found at
-`<https://support.ntp.org/bin/view/Servers/NTPPoolServers>`_.
+`<https://support.ntp.org/bin/view/Servers/NTPPoolServers>`__.
 For time accuracy, choose NTP servers that are geographically close to
 the %brand% system's physical location.
 
@@ -267,7 +267,7 @@ to open the screen shown in
 :numref:`Figure %s <ntp_server_fig>`.
 :numref:`Table %s <ntp_server_conf_opts_tab>`
 summarizes the options available when adding an NTP server.
-`ntp.conf(5) <http://www.freebsd.org/cgi/man.cgi?query=ntp.conf>`_
+`ntp.conf(5) <https://www.freebsd.org/cgi/man.cgi?query=ntp.conf>`__
 explains these options in more detail.
 
 
@@ -617,7 +617,7 @@ The configurable settings are summarized in
    | Enable screen saver                      | checkbox                         | enable or disable the console screen saver                                   |
    |                                          |                                  |                                                                              |
    +------------------------------------------+----------------------------------+------------------------------------------------------------------------------+
-   | Enable powerd (Power Saving Daemon)      | checkbox                         | `powerd(8) <http://www.freebsd.org/cgi/man.cgi?query=powerd>`_               |
+   | Enable powerd (Power Saving Daemon)      | checkbox                         | `powerd(8) <https://www.freebsd.org/cgi/man.cgi?query=powerd>`__             |
    |                                          |                                  | monitors the system state and sets the CPU frequency accordingly             |
    |                                          |                                  |                                                                              |
    #ifdef freenas
@@ -664,7 +664,7 @@ The configurable settings are summarized in
    |                                          |                                  |                                                                              |
    +------------------------------------------+----------------------------------+------------------------------------------------------------------------------+
    | Remote Graphite Server hostname          | string                           | IP address or hostname of a remote server running                            |
-   |                                          |                                  | `Graphite <http://graphite.wikidot.com/>`_                                   |
+   |                                          |                                  | `Graphite <http://graphiteapp.org/>`__                                       |
    |                                          |                                  |                                                                              |
    +------------------------------------------+----------------------------------+------------------------------------------------------------------------------+
    | Use FQDN for logging                     | checkbox                         | when checked, include the Fully-Qualified Domain Name in logs to precisely   |
@@ -820,7 +820,7 @@ shown in
    |                      |                      |                                                                                                 |
    +----------------------+----------------------+-------------------------------------------------------------------------------------------------+
    | Use                  | checkbox             | enable/disable                                                                                  |
-   | SMTP                 |                      | `SMTP AUTH <http://en.wikipedia.org/wiki/SMTP_Authentication>`_                                 |
+   | SMTP                 |                      | `SMTP AUTH <https://en.wikipedia.org/wiki/SMTP_Authentication>`__                               |
    | Authentication       |                      | using PLAIN SASL; if checked, enter the required :guilabel:`Username` and                       |
    |                      |                      | :guilabel:`Password`                                                                            |
    +----------------------+----------------------+-------------------------------------------------------------------------------------------------+
@@ -843,7 +843,7 @@ the *root* account in :menuselection:`Account --> Users --> View Users`.
 
 Configuring email for TLS/SSL email providers is described in
 `Are you having trouble getting FreeNAS to email you in Gmail?
-<https://forums.freenas.org/index.php?threads/are-you-having-trouble-getting-freenas-to-email-you-in-gmail.22517/>`_.
+<https://forums.freenas.org/index.php?threads/are-you-having-trouble-getting-freenas-to-email-you-in-gmail.22517/>`__.
 
 
 .. note: The %brand% user who receives periodic email can be set with
@@ -939,7 +939,7 @@ Tunables
 can be used to manage the following:
 
 #. **FreeBSD sysctls:** a
-   `sysctl(8) <http://www.freebsd.org/cgi/man.cgi?query=sysctl>`_
+   `sysctl(8) <https://www.freebsd.org/cgi/man.cgi?query=sysctl>`__
    makes changes to the FreeBSD kernel running on a %brand% system
    and can be used to tune the system.
 
@@ -969,7 +969,8 @@ Since sysctl, loader, and rc.conf values are specific to the kernel
 parameter to be tuned, the driver to be loaded, or the service to
 configure, descriptions and suggested values can be found in the man
 page for the specific driver and in many sections of the
-`FreeBSD Handbook <http://www.freebsd.org/handbook>`_.
+`FreeBSD Handbook
+<https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/>`__.
 
 To add a loader, sysctl, or :file:`rc.conf` option, go to
 :menuselection:`System --> Tunables --> Add Tunable`,
@@ -1584,21 +1585,21 @@ system events that require attention. These events are system
 
 Currently available alert services:
 
-* `AWS-SNS <https://aws.amazon.com/sns/>`_
+* `AWS-SNS <https://aws.amazon.com/sns/>`__
 
-* `Hipchat <https://www.hipchat.com/>`_
+* `Hipchat <https://www.atlassian.com/software/hipchat>`__
 
-* `InfluxDB <https://www.influxdata.com/>`_
+* `InfluxDB <https://www.influxdata.com/>`__
 
-* `Slack <https://slack.com/>`_
+* `Slack <https://slack.com/>`__
 
-* `Mattermost <https://about.mattermost.com/>`_
+* `Mattermost <https://about.mattermost.com/>`__
 
-* `OpsGenie <https://www.opsgenie.com/>`_
+* `OpsGenie <https://www.opsgenie.com/>`__
 
-* `PagerDuty <https://www.pagerduty.com/>`_
+* `PagerDuty <https://www.pagerduty.com/>`__
 
-* `VictorOps <https://victorops.com/>`_
+* `VictorOps <https://victorops.com/>`__
 
 
 .. warning:: These alert services might use a third party commercial
@@ -1734,7 +1735,7 @@ The configurable options are summarized in
 To instead create a new CA, first decide if it will be the only CA
 which will sign certificates for internal use or if the CA will be
 part of a
-`certificate chain <https://en.wikipedia.org/wiki/Root_certificate>`_.
+`certificate chain <https://en.wikipedia.org/wiki/Root_certificate>`__.
 
 
 To create a CA for internal use only, click the
@@ -2199,7 +2200,7 @@ generate and send the support ticket to iXsystems. A pop-up menu
 provides a clickable URL to view the status of or add additional
 information to that support ticket.
 When not already logged into the
-`iXsystems Support page <https://support.ixsystems.com/>`_, clicking
+`iXsystems Support page <https://support.ixsystems.com/>`__, clicking
 this URL prompts for a login, or to register a new login.
 
 
@@ -2319,7 +2320,7 @@ seconds rather than the minutes of other configurations, significantly
 reducing the chance of a client timeout.
 
 The Common Address Redundancy Protocol
-(`CARP <http://www.openbsd.org/faq/pf/carp.html>`_)
+(`CARP <http://www.openbsd.org/faq/pf/carp.html>`__)
 is used to provide high availability and failover. CARP was originally
 developed by the OpenBSD project and provides an open source, non
 patent-encumbered alternative to the VRRP and HSRP protocols.

--- a/userguide/tasks.rst
+++ b/userguide/tasks.rst
@@ -245,7 +245,7 @@ The completed dialog is shown in
 Cron Jobs
 ---------
 
-`cron(8) <http://www.freebsd.org/cgi/man.cgi?query=cron>`_
+`cron(8) <https://www.freebsd.org/cgi/man.cgi?query=cron>`__
 is a daemon that runs a command or script on a regular schedule as a
 specified user.
 
@@ -395,7 +395,7 @@ has been fully tested to ensure it achieves the desired results.
 Rsync Tasks
 -----------
 
-`Rsync <http://www.samba.org/ftp/rsync/rsync.html>`_
+`Rsync <https://www.samba.org/ftp/rsync/rsync.html>`__
 is a utility that copies specified data from one system to another
 over a network. Once the initial data is copied, rsync reduces the
 amount of data sent over the network by sending only the differences
@@ -406,7 +406,7 @@ between systems.
 Rsync is most effective when only a relatively small amount of the
 data has changed. There are also
 `some limitations when using Rsync with Windows files
-<https://forums.freenas.org/index.php?threads/impaired-rsync-permissions-support-for-windows-datasets.43973/>`_.
+<https://forums.freenas.org/index.php?threads/impaired-rsync-permissions-support-for-windows-datasets.43973/>`__.
 For large amounts of data, data that has many changes from the
 previous copy, or Windows files, :ref:`Replication Tasks` are often
 the faster and better solution.
@@ -438,7 +438,7 @@ on the rsync client.
   server. It can be defined in the %brand% GUI under
   :menuselection:`Services --> Rsync --> Rsync Modules`.
   In other operating systems, the module is defined in
-  `rsyncd.conf(5) <http://www.samba.org/ftp/rsync/rsyncd.conf.html>`_.
+  `rsyncd.conf(5) <https://www.samba.org/ftp/rsync/rsyncd.conf.html>`__.
 
 * **rsync over SSH:** synchronizes over an encrypted connection.
   Requires the configuration of SSH user and host public keys.
@@ -502,7 +502,7 @@ task.
    |                                  |                             |                                                                                           |
    +----------------------------------+-----------------------------+-------------------------------------------------------------------------------------------+
    | Remote Module Name               | string                      | only appears when using *Rsync module* mode, at least one module must be defined in       |
-   |                                  |                             | `rsyncd.conf(5) <http://www.samba.org/ftp/rsync/rsyncd.conf.html>`_                       |
+   |                                  |                             | `rsyncd.conf(5) <https://www.samba.org/ftp/rsync/rsyncd.conf.html>`__                     |
    |                                  |                             | of rsync server or in the :guilabel:`Rsync Modules` of another                            |
    |                                  |                             | system                                                                                    |
    |                                  |                             |                                                                                           |
@@ -564,14 +564,14 @@ task.
    |                                  |                             |                                                                                           |
    +----------------------------------+-----------------------------+-------------------------------------------------------------------------------------------+
    | Preserve extended attributes     | checkbox                    | both systems must support                                                                 |
-   |                                  |                             | `extended attributes <http://en.wikipedia.org/wiki/Xattr>`_                               |
+   |                                  |                             | `extended attributes <https://en.wikipedia.org/wiki/Xattr>`__                             |
    |                                  |                             |                                                                                           |
    +----------------------------------+-----------------------------+-------------------------------------------------------------------------------------------+
    | Delay Updates                    | checkbox                    | when checked, the temporary file from each updated file is saved to a holding directory   |
    |                                  |                             | until the end of the transfer, when all transferred files are renamed into place          |
    |                                  |                             |                                                                                           |
    +----------------------------------+-----------------------------+-------------------------------------------------------------------------------------------+
-   | Extra options                    | string                      | `rsync(1) <http://rsync.samba.org/ftp/rsync/rsync.html>`_                                 |
+   | Extra options                    | string                      | `rsync(1) <http://rsync.samba.org/ftp/rsync/rsync.html>`__                                |
    |                                  |                             | options not covered by the GUI; if the :literal:`*` character is used, it                 |
    |                                  |                             | must be escaped with a backslash (:literal:`\\*.txt`)                                     |
    |                                  |                             | or used inside single quotes (:literal:`'*.txt'`)                                         |
@@ -820,7 +820,7 @@ just before the *\n* in the error message.
 S.M.A.R.T. Tests
 ----------------
 
-`S.M.A.R.T. <http://en.wikipedia.org/wiki/S.M.A.R.T.>`_
+`S.M.A.R.T. <https://en.wikipedia.org/wiki/S.M.A.R.T.>`__
 (Self-Monitoring, Analysis and Reporting Technology) is a monitoring
 system for computer hard disk drives to detect and report on various
 indicators of reliability. When a failure is anticipated by
@@ -873,7 +873,7 @@ summarizes the configurable options when creating a S.M.A.R.T. test.
    |                   |                           |                                                                                                            |
    +-------------------+---------------------------+------------------------------------------------------------------------------------------------------------+
    | Type              | drop-down menu            | select type of test to run; see                                                                            |
-   |                   |                           | `smartctl(8) <https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in>`_                   |
+   |                   |                           | `smartctl(8) <https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in>`__                  |
    |                   |                           | for a description of each type of test (note that some test types will degrade performance or take disks   |
    |                   |                           | offline; do not schedule S.M.A.R.T. tests at the same time as a scrub or during a resilver operation)      |
    |                   |                           |                                                                                                            |

--- a/userguide/tn_cinder.rst
+++ b/userguide/tn_cinder.rst
@@ -17,7 +17,7 @@ Requirements
 1. A %brand% 11.0 or newer system to provide storage.
 
 2. A computer running the
-   `Newton release <https://docs.openstack.org/newton/>`_
+   `Newton release <https://docs.openstack.org/newton/>`__
    of OpenStack or newer, with these minimum hardware requirements:
 
    * 4 GiB of RAM
@@ -132,7 +132,7 @@ Here is an example of typical additional parameter settings for a
 
 
 .. tip:: The
-   `OpenStack documentation <https://docs.openstack.org/mitaka/config-reference/block-storage/block-storage-sample-configuration-files.html>`_
+   `OpenStack documentation <https://docs.openstack.org/mitaka/config-reference/block-storage/block-storage-sample-configuration-files.html>`__
    also provides examples of :file:`cinder.conf` configurations.
 
 

--- a/userguide/tn_initial.rst
+++ b/userguide/tn_initial.rst
@@ -318,7 +318,7 @@ check these things:
   issues and will not display the graphical administrative interface
   correctly if compatibility mode is turned on. If the GUI cannot
   be accessed with Internet Explorer, use
-  `Firefox <https://www.mozilla.org/en-US/firefox/all/>`_
+  `Firefox <https://www.mozilla.org/en-US/firefox/all/>`__
   instead.
 
 * If "An error occurred!" messages are shown when attempting to
@@ -326,7 +326,7 @@ check these things:
   to allow cookies from the %brand% system.
 
 This
-`blog post <http://fortysomethinggeek.blogspot.com/2012/10/ipad-iphone-connect-with-freenas-or-any.html>`_
+`blog post <http://fortysomethinggeek.blogspot.com/2012/10/ipad-iphone-connect-with-freenas-or-any.html>`__
 describes some applications which can be used to access the %brand%
 system from an iPad or iPhone.
 

--- a/userguide/tn_options.rst
+++ b/userguide/tn_options.rst
@@ -16,7 +16,7 @@ Display System Processes
 
 Clicking :guilabel:`Display System Processes` opens a screen showing
 the output of
-`top(1) <http://www.freebsd.org/cgi/man.cgi?query=top>`_.
+`top(1) <https://www.freebsd.org/cgi/man.cgi?query=top>`__.
 An example is shown in
 :numref:`Figure %s <process>`.
 

--- a/userguide/tn_vcenter.rst
+++ b/userguide/tn_vcenter.rst
@@ -8,7 +8,7 @@ vCenter Plugin
 The %brand% vCenter Plugin integrates the control and operation of
 %brand% into
 `VMware vCenter Server
-<https://www.vmware.com/products/vcenter-server>`_.
+<https://www.vmware.com/products/vcenter-server.html>`__.
 
 
 New Features in 2.1.0

--- a/userguide/vaai.rst
+++ b/userguide/vaai.rst
@@ -27,7 +27,7 @@ VAAI for iSCSI supports these operations:
 * *Clone Blocks* (*XCOPY*) copies disk blocks on the NAS. Copies occur
   locally rather than over the network. The operation is similar to
   `Microsoft ODX
-  <https://technet.microsoft.com/en-us/library/hh831628>`_.
+  <https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/hh831628(v=ws.11)>`__.
 
 * *LUN Reporting* allows a hypervisor to query the NAS to determine
   whether a LUN is using thin provisioning.
@@ -63,7 +63,7 @@ VAAI for iSCSI supports these operations:
 VAAI for NAS
 ------------
 
-`VAAI for NAS <https://code.vmware.com/programs/vaai-nas>`_
+`VAAI for NAS <https://code.vmware.com/programs/vaai-nas>`__
 is automatically enabled on %brand% when the :ref:`NFS` service is
 running. These operations are supported:
 

--- a/userguide/vms.rst
+++ b/userguide/vms.rst
@@ -410,7 +410,7 @@ inside containers. A container provides a complete filesystem,
 runtime, system tools, and system libraries, so applications always
 see the same environment.
 
-`Rancher <http://rancher.com/>`__
+`Rancher <https://rancher.com/>`__
 is a GUI tool for managing Docker containers.
 
 %brand% runs the Rancher GUI as a separate VM.

--- a/userguide/wizard.rst
+++ b/userguide/wizard.rst
@@ -67,7 +67,7 @@ been formatted.
 
 Enter a name for the ZFS pool that conforms to these
 `naming conventions
-<http://docs.oracle.com/cd/E23824_01/html/821-1448/gbcpt.html>`_.
+<https://docs.oracle.com/cd/E23824_01/html/821-1448/gbcpt.html>`__.
 It is recommended to choose a name that will stick out in the logs
 #ifdef freenas
 (e.g. **not** :file:`data` or :file:`freenas`).
@@ -233,7 +233,7 @@ through
    |                         |                |                                                                                                       |
    +-------------------------+----------------+-------------------------------------------------------------------------------------------------------+
    | Secure mode             | checkbox       | if checked,                                                                                           |
-   |                         |                | `ypbind(8) <http://www.freebsd.org/cgi/man.cgi?query=ypbind>`_                                        |
+   |                         |                | `ypbind(8) <https://www.freebsd.org/cgi/man.cgi?query=ypbind>`__                                      |
    |                         |                | will refuse to bind to any NIS server that is not running as root on a TCP port number over 1024      |
    |                         |                |                                                                                                       |
    +-------------------------+----------------+-------------------------------------------------------------------------------------------------------+

--- a/userguide/zfsprimer.rst
+++ b/userguide/zfsprimer.rst
@@ -10,7 +10,7 @@ to provide features not available in traditional UNIX filesystems. It
 was originally developed at Sun with the intent to open source the
 filesystem so that it could be ported to other operating systems.
 After the Oracle acquisition of Sun, some of the original ZFS
-engineers founded `OpenZFS <http://open-zfs.org/wiki/Main_Page>`_
+engineers founded `OpenZFS <http://open-zfs.org/wiki/Main_Page>`__
 to provide continued, collaborative development of the open
 source version. To differentiate itself from Oracle ZFS version
 numbers, OpenZFS uses feature flags. Feature flags are used to tag
@@ -24,7 +24,7 @@ Here is an overview of the features provided by ZFS:
 
 **ZFS is a transactional, Copy-On-Write**
 `(COW)
-<https://en.wikipedia.org/wiki/ZFS#Copy-on-write_transactional_model>`_
+<https://en.wikipedia.org/wiki/ZFS#Copy-on-write_transactional_model>`__
 filesystem. For each write request, a copy is made of the associated
 disk blocks and all changes are made to the copy rather than to the
 original blocks. When the write is complete, all block pointers are
@@ -35,7 +35,7 @@ successfully. ZFS has direct access to disks and bundles multiple read
 and write requests into transactions. Most filesystems cannot do this,
 as they only have access to disk blocks. A transaction either
 completes or fails, meaning there will never be a
-`write-hole <https://blogs.oracle.com/bonwick/entry/raid_z>`_
+`write-hole <https://blogs.oracle.com/bonwick/raid-z>`__
 and a filesystem checker utility is not necessary. Because of the
 transactional design, as additional storage capacity is added, it
 becomes immediately available for writes. To rebalance the data, one
@@ -119,11 +119,11 @@ changes.
 
 **ZFS provides a write cache** in RAM as well as a ZFS Intent Log
 (`ZIL
-<https://blogs.oracle.com/realneel/entry/the_zfs_intent_log>`_).
+<http://www.freenas.org/blog/zfs-zil-and-slog-demystified/>`__).
 The ZIL is a storage area that
 `temporarily holds *synchronous* writes until they are written to the
 ZFS pool
-<https://pthree.org/2013/04/19/zfs-administration-appendix-a-visualizing-the-zfs-intent-log/>`_.
+<https://pthree.org/2013/04/19/zfs-administration-appendix-a-visualizing-the-zfs-intent-log/>`__.
 Adding a fast (low-latency), power-protected SSD as a SLOG
 (*Separate Log*) device permits much higher performance. This is a
 necessity for NFS over ESXi, and highly recommended for database
@@ -132,20 +132,20 @@ detail on SLOG benefits and usage is available in these blog and forum
 posts:
 
 * `The ZFS ZIL and SLOG Demystified
-  <http://www.freenas.org/blog/zfs-zil-and-slog-demystified/>`_
+  <http://www.freenas.org/blog/zfs-zil-and-slog-demystified/>`__
 
 * `Some insights into SLOG/ZIL with ZFS on FreeNAS®
-  <https://forums.freenas.org/index.php?threads/some-insights-into-slog-zil-with-zfs-on-freenas.13633/>`_
+  <https://forums.freenas.org/index.php?threads/some-insights-into-slog-zil-with-zfs-on-freenas.13633/>`__
 
 * `ZFS Intent Log
-  <http://nex7.blogspot.com/2013/04/zfs-intent-log.html>`_
+  <http://nex7.blogspot.com/2013/04/zfs-intent-log.html>`__
 
 Synchronous writes are relatively rare with SMB, AFP, and iSCSI, and
 adding a SLOG to improve performance of these protocols only makes
 sense in special cases. The :command:`zilstat` utility can be run from
 :ref:`Shell` to determine if the system will benefit from a SLOG. See
 `this website
-<http://www.richardelling.com/Home/scripts-and-programs-1/zilstat>`_
+<http://www.richardelling.com/Home/scripts-and-programs-1/zilstat>`__
 for usage information.
 
 ZFS currently uses 16 GB of space for SLOG. Larger SSDs can be
@@ -164,11 +164,11 @@ value of *-* means the ZFS pool is version 5000 (also known as
 
 **ZFS provides a read cache** in RAM, known as the ARC, which reduces
 read latency. %brand% adds ARC stats to
-`top(1) <http://www.freebsd.org/cgi/man.cgi?query=top>`_
+`top(1) <https://www.freebsd.org/cgi/man.cgi?query=top>`__
 and includes the :command:`arc_summary.py` and :command:`arcstat.py`
 tools for monitoring the efficiency of the ARC. If an SSD is dedicated
 as a cache device, it is known as an
-`L2ARC <https://blogs.oracle.com/brendan/entry/test>`_.
+`L2ARC <http://www.brendangregg.com/blog/2008-07-22/zfs-l2arc.html>`__.
 Additional read data is cached here, which can increase random read
 performance. L2ARC does *not* reduce the need for sufficient RAM. In
 fact, L2ARC needs RAM to function. If there is not enough RAM for a
@@ -235,10 +235,10 @@ These resources can also help determine the RAID configuration best
 suited to your storage needs:
 
 * `Getting the Most out of ZFS Pools
-  <https://forums.freenas.org/index.php?threads/getting-the-most-out-of-zfs-pools.16/>`_
+  <https://forums.freenas.org/index.php?threads/getting-the-most-out-of-zfs-pools.16/>`__
 
 * `A Closer Look at ZFS, Vdevs and Performance
-  <http://constantin.glez.de/blog/2010/06/closer-look-zfs-vdevs-and-performance>`_
+  <https://constantin.glez.de/2010/06/04/a-closer-look-zfs-vdevs-and-performance/>`__
 
 .. warning:: RAID AND DISK REDUNDANCY ARE NOT A SUBSTITUTE FOR A
    RELIABLE BACKUP STRATEGY. BAD THINGS HAPPEN AND A GOOD BACKUP
@@ -285,13 +285,13 @@ provides an excellent starting point to learn more about its features.
 These resources are also useful for reference:
 
 * `FreeBSD ZFS Tuning Guide
-  <https://wiki.FreeBSD.org/ZFSTuningGuide>`__
+  <https://wiki.freebsd.org/ZFSTuningGuide>`__
 
 * `ZFS Administration Guide
-  <http://docs.oracle.com/cd/E19253-01/819-5461/index.html>`__
+  <https://docs.oracle.com/cd/E19253-01/819-5461/index.html>`__
 
 * `Becoming a ZFS Ninja (video)
-  <https://blogs.oracle.com/video/entry/becoming_a_zfs_ninja>`__
+  <https://www.youtube.com/watch?v=6_K55Ira1Cs>`__
 
 * `Slideshow explaining VDev, zpool, ZIL and L2ARC and other
   newbie mistakes!


### PR DESCRIPTION
Exhaustive review of all links contained in every .rst file to fix broken links,
update http -> https addresses, and update link syntax to use two underscores (`_ -> `__).
Conducted link testing with both make linkcheck and manually.
There are a few "false positive" links remaining that display an error or warning, but do actually work properly.
HTML build testing for both FreeNAS and TrueNAS guides: no issues.