### PR TITLE
Misc updates to AFP and SMB sharing docs

### DIFF
--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -34,13 +34,15 @@ system to meet the requirements of the network.
 
 These types of shares and services are available:
 
-* :ref:`AFP <Apple (AFP) Shares>`: Apple File Protocol shares are
-  often used when the client computers all run macOS. Apple has
-  slowly shifted to preferring :ref:`SMB <Windows (SMB) Shares>` for
-  modern networks, although Time Machine still requires AFP.
+* :ref:`AFP <Apple (AFP) Shares>`: Apple Filing Protocol shares are
+  used when the client computers all run macOS. Apple has deprecated
+  AFP in favour of :ref:`SMB <Windows (SMB) Shares>` and using AFP
+  in modern networks is no longer recommanded (except for providing a
+  Time Machine, for which %brand% currently only supports AFP, not
+  yet SMB).
 
 * :ref:`Unix (NFS) <Unix (NFS) Shares>`: Network File System shares
-  are accessible from Mac OS X, Linux, BSD, and the professional and
+  are accessible from macOS, Linux, BSD, and the professional and
   enterprise versions (but not the home editions) of Windows. This can
   be are a good choice when the client computers do not all run the
   same operating system but NFS client software is available for all
@@ -53,10 +55,10 @@ These types of shares and services are available:
 
 * :ref:`SMB <Windows (SMB) Shares>`: Server Message Block shares, also
   known as Common Internet File System (CIFS) shares, are accessible
-  by Windows, Mac OS X, Linux, and BSD computers. Access is slower
+  by Windows, macOS, Linux, and BSD computers. Access is slower
   than an NFS share due to the single-threaded design of Samba. SMB
-  provides more configuration options than NFS and is a good choice
-  on a network for Windows systems. However, it is a poor choice if
+  provides more configuration options than NFS and is the best choice
+  on a network for Windows or Mac systems. However, it is a poor choice if
   the CPU on the %brand% system is limited; if the CPU is maxed out,
   upgrade the CPU or consider another type of share.
 
@@ -197,8 +199,8 @@ information given when the share was created.
    |                              |               |          | automounting or volumes created by a preexec script.                                                          |
    |                              |               |          |                                                                                                               |
    +------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------------+
-   | AFP3 UNIX Privs              | checkbox      | ✓        | Enable Unix privileges supported by OSX 10.5 and higher. Do not enable this if the network contains           |
-   |                              |               |          | macOS 10.4 clients or lower as they do not support this feature.                                              |
+   | AFP3 UNIX Privs              | checkbox      | ✓        | Enable Unix privileges supported by Mac OS X 10.5 and higher. Do not enable this if the network contains           |
+   |                              |               |          | Mac OS X 10.4 clients or lower as they do not support this feature.                                              |
    |                              |               |          |                                                                                                               |
    +------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------------+
    | Default file permission      | checkboxes    | ✓        | Only works with Unix ACLs. New files created on the share are set with the selected permissions.              |
@@ -285,7 +287,7 @@ the AFP service so the share is immediately available. The new share
 is also added as an entry to
 :menuselection:`Sharing --> Apple (AFP)`.
 
-macOS users can connect to the guest AFP share by clicking
+macOS users can connect to the guest AFP share from the Finder by clicking
 :menuselection:`Go --> Connect to Server`. In the example shown in
 :numref:`Figure %s <afp_connect_server_fig>`,
 the user has entered *afp://* followed by the IP address of the
@@ -314,10 +316,11 @@ the :guilabel:`Shared` sidebar.
 Creating Authenticated and Time Machine Shares
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-macOS includes the Time Machine application which can be used to
-schedule automatic backups.  In this configuration example, a Time
+macOS includes the Time Machine feature which can be used to
+perform automatic backups.  In this configuration example, a Time
 Machine user will be configured to backup to an AFP share on a
-%brand% system. Creating a separate Time Machine
+%brand% system. (%brand% does not yet support Time Machine over SMB.)
+Creating a separate Time Machine
 share for each user that will be using Time Machine to backup their
 macOS system to %brand% is recommended. The process for creating
 an authenticated share for a user is the same as creating a
@@ -755,7 +758,7 @@ best results, use :ref:`Windows (SMB) Shares`.
 From macOS
 ^^^^^^^^^^^^^
 
-To mount the NFS volume from a macOS client, click on
+To mount the NFS volume from a macOS client, from the Finder click on
 :menuselection:`Go --> Connect to Server`.
 In the :guilabel:`Server Address` field, enter *nfs://* followed by
 the IP address of the %brand% system and the name of the
@@ -1258,7 +1261,7 @@ for more details.
    | streams_depot       | **Experimental** module to store alternate data streams in a central directory; the association with the primary file can be lost due      |
    |                     | to inode numbers changing when a directory is copied to a new location (see `<https://marc.info/?l=samba&m=132542069802160&w=2>`__).       |
    +---------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
-   | streams_xattr       | Enables storing of NTFS alternate data streams in the file system.                                                                         |
+   | streams_xattr       | Enables storing of NTFS alternate data streams in the file system; enabled by default.                                                     |
    |                     |                                                                                                                                            |
    +---------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
    | syncops             | Ensures metadata operations are performed synchronously.                                                                                   |
@@ -1379,7 +1382,7 @@ the administrator to control access to data, provide appropriate
 permissions to that data, and to determine who accesses and modifies
 stored data. A Windows domain controller is not needed for
 authenticated SMB shares, which means that additional licensing costs
-are not required. However, since there is no domain controller to
+are not required. However, when there is no domain controller to
 provide authentication for the network, each user account needs to be
 created on the %brand% system. This type of configuration scenario is
 often used in home and small networks as it does not scale well if
@@ -2487,7 +2490,7 @@ This
 <https://www.pluralsight.com/blog/software-development/freenas-8-iscsi-target-windows-7>`__
 shows how to create an iSCSI target for a Windows 7 system.
 
-Mac OS X does not include an initiator.
+macOS does not include an initiator.
 `globalSAN
 <http://www.studionetworksolutions.com/globalsan-iscsi-initiator/>`__
 is a commercial, easy-to-use Mac initiator.


### PR DESCRIPTION
Notably:
- note that Time Machine does not yet work on SMB
- use current name of "macOS" where appropriate
- other clarifications after reading this for the first time and using it to try FreeNAS for the first time