### PR TITLE
Fix name error in `iocage destroy` example (Redmine issue #35113):

### DIFF
--- a/userguide/jails.rst
+++ b/userguide/jails.rst
@@ -1501,7 +1501,7 @@ Jails are deleted with :command:`iocage destroy`:
    This will destroy jail examplejail
 
    Are you sure? [y/N]: y
-   Destroying newjail01
+   Destroying examplejail
 
 To adjust the properties of a jail, use :command:`iocage set` and
 :command:`iocage get`. All properties of a jail are viewed with


### PR DESCRIPTION
- Update jail name in example to match the command.
- HTML build testing: no issues
- https://redmine.ixsystems.com/issues/35113