### PR TITLE
Reviewed the shell.rst:

### DIFF
--- a/userguide/shell.rst
+++ b/userguide/shell.rst
@@ -26,13 +26,14 @@ The prompt indicates that the current user is *root*, the hostname is
 The :guilabel:`Set font size` slider adjusts the size of text
 displayed in the Shell.
 
-Highlight the text and use :command:`ctrl c` to copy text from
-the Shell. :command:`ctrl v` is used to paste text into the Shell.
+If using Firefox, highlight the text and use the Open menu in the top
+right of the browser to copy the text from the Shell. Use the edit
+option in the Open menu again to paste text into the Shell.
 
-Shell provides history (use the up arrow to see previously entered
+Shell provides history, use the up arrow to see previously entered
 commands and press :kbd:`Enter` to repeat the currently displayed
-command) and tab completion (type a few letters and press tab to
-complete a command name or filename in the current directory).
+command. It also provides tab completion, type a few letters and press tab to
+complete a command name or filename in the current directory.
 Type :command:`exit` to leave the
 session.
 


### PR DESCRIPTION
Tested the ctrl + c and ctrl + v options to copy and paste in the Shell console in Firefox and they didn't work. Ctrl + c will actually cancel any processes running so it is important that we don't tell users to do that. If you want to copy any text in the shell console in Firefox, the only way to do that is by using the edit option in Firefox's open menu in the top right. I've updated the docs accordingly. 

Passed build test with no errors. 