### PR TITLE
Fix error concerning iocage inclusion:

### DIFF
--- a/userguide/jails.rst
+++ b/userguide/jails.rst
@@ -1342,7 +1342,7 @@ available:
 Using iocage
 ------------
 
-Beginning with %brand% 9.10.1, the
+Beginning with %brand% 11.0, the
 `iocage <https://github.com/iocage/iocage>`__
 command line utility is included for creating and managing jails.
 Click the :guilabel:`Shell` option to  open the command line and begin


### PR DESCRIPTION
- Review GitHub commit history and verify iocage isn't tagged before FN 11.0
- Update text to reflect that iocage was added with FN 11.0
- HTML build test: no issues.