### PR TITLE
Add text descriptions of customizing tables:

### DIFF
--- a/userguide/account.rst
+++ b/userguide/account.rst
@@ -164,9 +164,11 @@ accounts installed with the %brand% operating system, as shown in
    Managing User Accounts
 
 
-Each user entry displays the username, user ID, primary group ID,
-home directory, default shell, built-in user, and other
-configured options.
+By default, each user entry displays the username, home directory,
+default shell, the user full name, and if the user is locked. This table
+is adjustable by setting the different column checkboxes above it. Set
+:guilabel:`Toggle` to display all options in the table.
+
 Clicking a column name sorts the list by that value. An arrow
 indicates which column controls the view sort order. Click the arrow to
 reverse the sort order.

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1427,11 +1427,11 @@ Disks
 To view all of the disks recognized by the %brand% system, use
 :menuselection:`Storage --> Disks`. As seen in the example in
 :numref:`Figure %s <viewing_disks_fig>`, each disk entry displays its
-device name, its pool membership, its status, serial number, size,
-description, transfer mode, standby mode, APM status, acoustic level,
-S.M.A.R.T. status, and configured S.M.A.R.T. options.
-
-as well as any read, write, or checksum errors.
+device name, pool membership, serial number, size, advanced power
+management settings, acoustic level settings, and if :ref:`S.M.A.R.T.`
+testing is enabled. This table is adjustable by setting the different
+column checkboxes above it. Set :guilabel:`Toggle` to display all
+options in the table.
 
 
 .. _viewing_disks_fig:

--- a/userguide/tasks.rst
+++ b/userguide/tasks.rst
@@ -116,9 +116,12 @@ lists the configurable options for a cron job.
    +-------------------+-----------------------------+---------------------------------------------------------------------------------------------------------+
 
 
-Cron jobs are shown in :menuselection:`Tasks --> Cron Jobs`.
-Click |ui-options| to see the :guilabel:`Edit` and :guilabel:`Delete`
-buttons.
+Cron jobs are shown in :menuselection:`Tasks --> Cron Jobs`. This table
+displays the user, command, description, schedule, and if the job is
+enabled. This table is adjustable by setting the different column
+checkboxes above it. Set :guilabel:`Toggle` to display all options in
+the table. Click |ui-options| for an entry to see the :guilabel:`Edit`
+and :guilabel:`Delete` buttons.
 
 
 .. note:: :literal:`%` symbols are automatically escaped and should


### PR DESCRIPTION
- 34077: tables in Account/Users, Storage/Disks, and Tasks/Cron Jobs have customizable columns.
- Add descriptions in each relevant chapter to reflect this change.
- HTML build test: no issues.