### PR TITLE
Describe input limitations of the S3 Access Key and Secret Key fields.

### DIFF
--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1138,11 +1138,12 @@ configuration options. After configuring the S3 service, start it in
    | Port            | string         | Enter the TCP port on which to provide the S3 service. Default is 9000.                        |
    |                 |                |                                                                                                |
    +-----------------+----------------+------------------------------------------------------------------------------------------------+
-   | Access Key      | string         | Enter the S3 user name. Must be between 5 and 20 characters long.                              |
+   | Access Key      | string         | Enter the S3 user name. This username must contain **only** alphanumeric characters and be     |
+   |                 |                | between 5 and 20 characters long.                                                              |
    |                 |                |                                                                                                |
    +-----------------+----------------+------------------------------------------------------------------------------------------------+
-   | Secret Key      | string         | Enter the password to be used by connecting S3 systems. Must be at least 8 but no more than 40 |
-   |                 |                | characters long.                                                                               |
+   | Secret Key      | string         | Enter the password to be used by connecting S3 systems. The key must contain **only**          |
+   |                 |                | alphanumeric characters and be at least 8 but no more than 40 characters long.                 |
    |                 |                |                                                                                                |
    +-----------------+----------------+------------------------------------------------------------------------------------------------+
    | Confirm S3 Key  | string         | Re-enter the S3 password to confirm.                                                           |


### PR DESCRIPTION
- 36968
- Add text warnings that only alphanumeric characters are allowed in the above mentioned fields.
- HTML build test: no issues.