### PR TITLE
Add Bold, Italic, and BoldItalic Font support:

### DIFF
--- a/userguide/conf.py
+++ b/userguide/conf.py
@@ -430,7 +430,12 @@ latex_engine = 'xelatex'
 if latex_engine == 'xelatex':
     font_init = r'''\usepackage{fontspec}%
                     \newfontfamily\opensansfont{OpenSans-Regular.ttf}[Scale=0.95]%
-                    \setmainfont{OpenSans-Regular.ttf}[Scale=0.95]%
+                    \setmainfont{OpenSans-Regular.ttf}[
+                          Scale=0.95 ,
+                          BoldFont = OpenSans-Bold.ttf ,
+                          ItalicFont = OpenSans-Italic.ttf ,
+                          BoldItalicFont = OpenSans-BoldItalic.ttf
+                          ]%
                     \setmonofont{FreeMono.otf}[Scale=0.95]%
                     \defaultfontfeatures{Ligatures=TeX}%
                     \newfontfamily{\awesome}[Scale = 0.95, Path = /usr/local/share/texmf-dist/fonts/opentype/public/fontawesome/]{FontAwesome.otf}'''


### PR DESCRIPTION
- This fixes all missing bold and italic rendering for PDF generation.
- PDF build test: no issues.
- Note: fontspec documentation requires manually setting the bold, italic, and bolditalic fonts when the main font is called by filename. See https://mirror.hmc.edu/ctan/macros/xetex/latex/fontspec/fontspec.pdf for more details.