### PR TITLE
Updated the note about locked volumes not showing in system dataset.

### DIFF
--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -974,7 +974,7 @@ controller users and groups.
    System Dataset Screen
 #endif truenas
 
-.. note:: Encrypted volumes are not displayed in the
+.. note:: Encrypted, locked volumes are not displayed in the
    :guilabel:`System dataset pool` drop-down menu.
 
 The system dataset can optionally be configured to also store the


### PR DESCRIPTION
Tested on master branch. In the old UI an encrypted, locked volume did not show up in the system data set drop down. This is a master branch change only.