### PR TITLE
Update documentation to reflect change from ticket 27756.

### DIFF
--- a/userguide/tasks.rst
+++ b/userguide/tasks.rst
@@ -1713,6 +1713,13 @@ schedule for running a cloud sync task. An example is shown in
 
    Cloud Sync Status
 
+
+When an existing task has run, a :literal:`✓` or :literal:`x` is shown
+to reflect the success or failure of the task. Click either symbol to
+open the :guilabel:`Logs` window. This window displays the logs related
+the task that ran. Click :guilabel:`DOWNLOAD LOGS` to open a popup
+window to download the :file:`.log` file.
+
 Click |ui-add| to display the :guilabel:`Add Cloud Sync` menu shown in
 :numref:`Figure %s <tasks_cloudsync_add_fig>`.
 
@@ -1802,6 +1809,7 @@ shows the configuration options for Cloud Syncs.
 
 To modify an existing cloud sync, click |ui-options| to access the
 :guilabel:`Run Now`, :guilabel:`Edit`, and :guilabel:`Delete` options.
+
 
 .. _Cloud Sync Example:
 


### PR DESCRIPTION
Add text describing seeing download logs for a successful or failed cloud sync task.
Master branch handbook needs this as well.
HTML test: no issues