### PR TITLE
Add missing comma to Identifier entry in Importing a CA Options table

### DIFF
--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -1888,8 +1888,8 @@ The configurable options are summarized in
    | Setting              | Value              | Description                                                                                       |
    |                      |                    |                                                                                                   |
    +======================+====================+===================================================================================================+
-   | Identifier           | string             | Enter a descriptive name for the CA using only alphanumeric                                       |
-   |                      |                    | underscore (:literal:`_`) and dash (:literal:`-`) characters.                                     |
+   | Identifier           | string             | Enter a descriptive name for the CA using only alphanumeric,                                      |
+   |                      |                    | underscore (:literal:`_`), and dash (:literal:`-`) characters.                                    |
    |                      |                    |                                                                                                   |
    +----------------------+--------------------+---------------------------------------------------------------------------------------------------+
    | Type                 | drop-down menu     | Choose the type of CA. Choices are *Internal CA*, *Intermediate CA*, and *Import CA*.             |

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -1889,7 +1889,7 @@ The configurable options are summarized in
    |                      |                    |                                                                                                   |
    +======================+====================+===================================================================================================+
    | Identifier           | string             | Enter a descriptive name for the CA using only alphanumeric                                       |
-   |                      |                    | underscore (:literal:`_`), and dash (:literal:`-`) characters.                                    |
+   |                      |                    | underscore (:literal:`_`) and dash (:literal:`-`) characters.                                     |
    |                      |                    |                                                                                                   |
    +----------------------+--------------------+---------------------------------------------------------------------------------------------------+
    | Type                 | drop-down menu     | Choose the type of CA. Choices are *Internal CA*, *Intermediate CA*, and *Import CA*.             |


### PR DESCRIPTION
HTML build test: no issues.
Check related tables to verify Identifier entry is correct.