### PR TITLE
Adjust services documentation to reflect the new view (47906)

### DIFF
--- a/userguide/conf.py
+++ b/userguide/conf.py
@@ -173,8 +173,9 @@ rst_prolog = u'''
 .. |ui-options|  replace:: ⋮ (Options)
 .. |ui-add|      replace:: **+** (Add/Create)
 .. |ui-power|    replace:: ⏻ (Power)
-.. |ui-configure| replace:: ✎ (Configure)
 .. |ui-password-show| replace:: 👁 (Show/Hide)
+.. |ui-configure| replace:: ✎ (Configure)
+.. |ui-launch| replace::  	■ (Launch)
 '''
 
 # roles for text replacement

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -55,11 +55,11 @@ Configure Services
 The :guilabel:`Services` page, shown in
 :numref:`Figure %s <control_services_fig>`,
 lists all services. The list has options to activate the service, set a
-service to :guilabel:`Start Automatically` at system boot, and
-|ui-configure| a service. The S.M.A.R.T. service is enabled by default,
-but only runs if the storage devices support
+service to :guilabel:`Start Automatically` at system boot, and configure
+a service. The S.M.A.R.T. service is enabled by default, but only runs
+if the storage devices support
 `S.M.A.R.T. data <https://en.wikipedia.org/wiki/S.M.A.R.T.>`__.
-Other services default to off until started.
+Other services default to *off* until started.
 
 .. _control_services_fig:
 
@@ -68,7 +68,7 @@ Other services default to off until started.
    Configure Services
 
 
-Stopped services show the sliding button on the left. Running services
+Stopped services show the sliding button on the left. Active services
 show the sliding button on the right. Click the slider to start or stop
 a service. Stopping a service shows a confirmation dialog.
 


### PR DESCRIPTION
Update text to reflect the current appearance of the new UI.
Add placeholder characters to represent the Pencil and Media_Playlist Material Design icons. These characters will need to be replaced when the new font is registered.
HTML build test: no issues.