### PR TITLE
Updated docs to reflect new UI changes

### DIFF
--- a/userguide/vms.rst
+++ b/userguide/vms.rst
@@ -124,7 +124,12 @@ Virtual machine configuration options are described in
    |          |                    |                | `gibibytes <https://simple.wikipedia.org/wiki/Gibibyte>`__ for the new zvol.                  |
    |          |                    |                | Only appears if :guilabel:`Create new disk image` is selected.                                |
    +----------+--------------------+----------------+-----------------------------------------------------------------------------------------------+
-   | 4        | Select datastore   | drop-down menu | Choose a datastore for the new zvol.                                                          |
+   | 4        | Select pool or     | drop-down menu | Select a pool or dataset for the new zvol.                                                    |
+   |          | dataset            |                |                                                                                               |
+   |          |                    |                |                                                                                               |
+   +----------+--------------------+----------------+-----------------------------------------------------------------------------------------------+
+   | 4        | Select disk type   | drop-down menu | Select the disk type. Choices are *AHCI* and *VirtIO*. Refer to                               |
+   |          |                    |                | :ref:`Disk Devices <vms-disk-device>` for more information about these disk types.            |
    |          |                    |                |                                                                                               |
    +----------+--------------------+----------------+-----------------------------------------------------------------------------------------------+
    | 5        | Adapter Type       | drop-down menu | :guilabel:`Intel e82545 (e1000)` emulates the same Intel Ethernet card. This                  |
@@ -141,11 +146,11 @@ Virtual machine configuration options are described in
    |          |                    |                |                                                                                               |
    |          |                    |                |                                                                                               |
    +----------+--------------------+----------------+-----------------------------------------------------------------------------------------------+
-   | 6        | Choose an          | browse button  | :guilabel:`Browse` to the operating system installation media.                                |
+   | 6        | Choose             | browse button  | :guilabel:`Browse` to the operating system installation media.                                |
    |          | installation media |                |                                                                                               |
    |          |                    |                |                                                                                               |
    +----------+--------------------+----------------+-----------------------------------------------------------------------------------------------+
-   | 6        | Upload an ISO?     | checkbox and   | Set to display image upload options.                                                          |
+   | 6        | Upload ISO         | checkbox and   | Set to display image upload options.                                                          |
    |          |                    | buttons        |                                                                                               |
    |          |                    |                |                                                                                               |
    +----------+--------------------+----------------+-----------------------------------------------------------------------------------------------+


### PR DESCRIPTION
- These changes are in response to bug #40444
- The ability to select a disk type (VirtIO and AHCI) was added to the VM Wizard in the UI so I updated the  VM Options Wizard table to reflect this change. 
- Updated "Select datastore" to "Select pool or dataset" to match the current name of the field in the UI.
- Passed build test with no issue. 

@wblock Just as a side note, I noticed we refer to screen # in the table below, but did we consider numbering the wizard pages in UI as well? 