### PR TITLE
The enable power saving daemon checkbox was removed from the UI 

### DIFF
--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -268,6 +268,9 @@ These screen options have changed:
   daily telemetry` checkbox has been removed from
   :menuselection:`System --> Advanced`.
 
+* The :guilabel:`Enable Power Saving Daemon` option has been
+  removed from :menuselection:`System --> Advanced`.
+
 * :guilabel:`Alert Settings` has been added to :guilabel:`System` and
   can be used to list the available alert conditions and to configure
   the notification frequency on a per-alert basis.

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -603,10 +603,6 @@ The configurable settings are summarized in
    |                                          |                    |                                                                                                  |
    #endif freenas
    +------------------------------------------+--------------------+--------------------------------------------------------------------------------------------------+
-   | Enable Power Saving Daemon               | checkbox           | `powerd(8) <https://www.freebsd.org/cgi/man.cgi?query=powerd>`__ monitors the system state and   |
-   |                                          |                    | sets the CPU frequency accordingly.                                                              |
-   |                                          |                    |                                                                                                  |
-   +------------------------------------------+--------------------+--------------------------------------------------------------------------------------------------+
    | Enable autotune                          | checkbox           | Enable the :ref:`autotune` script which attempts to optimize the system based on                 |
    |                                          |                    | the installed  hardware. *Warning*: Autotuning is only used as a temporary measure and is        |
    |                                          |                    | not a permanent fix for system hardware issues.                                                  |


### PR DESCRIPTION
- I removed the enable power saving option from the Advanced Configuration Settings table. 
- Passed build tests with no errors.
- This is in response to Bug #49398