### PR TITLE
We added some warning messages in the UI about not being able to delete, edit, or add 

### DIFF
--- a/userguide/jails.rst
+++ b/userguide/jails.rst
@@ -720,9 +720,9 @@ available for a jail.
    | points       | mount point to :guilabel:`Edit` or click |ui-add| to open     |
    |              | the :guilabel:`Add Mount Point` screen. A mount point         |
    |              | gives a jail access to storage located elsewhere on the       |
-   |              | system. A jail must be stopped before interacting with        |
-   |              | :guilabel:`Mount Points`. See :ref:`Additional Storage`       |
-   |              | for more details.                                             |
+   |              | system. A jail must be stopped before adding, editing, or     |
+   |              | deleting a :guilabel:`Mount Point`. See                       |
+   |              | :ref:`Additional Storage` for more details.                   |
    |              |                                                               |
    +--------------+---------------------------------------------------------------+
    | Restart      | Stop and immediately start an :literal:`up` jail.             |


### PR DESCRIPTION
a mount point while a jail is running so I clarified that in the docs.
Passed build test with no issues.
Related to https://redmine.ixsystems.com/issues/47184