### PR TITLE
Split a paragraph for ease of reading

### DIFF
--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1371,17 +1371,21 @@ changed, and destroying a zvol requires confirmation.
 Managing Encrypted Volumes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-%brand% generates and stores a randomized *encryption key* whenever
+%brand% generates a randomized *encryption key* whenever
 a new encrypted volume is created. This key is required to read and
-decrypt any data on the volume.
+decrypt any data on the volume. 
 
-Encryption keys can also be downloaded as a safety measure, to allow
-decryption on a different system in the event of failure, or to allow
-the locally stored key to be deleted for extra security. Encryption
-keys can also be optionally protected with a *passphrase* for
-additional security. The combination of encryption key location and
-whether a passphrase is used provide several different security
-scenarios:
+By default, %brand% stores encryption keys locally within its system
+settings, so that authorized users can easily login and decrypt volumes.
+
+Encryption keys can also be downloaded. This is useful as a safety
+measure, to allow key backup, decryption on a different system in the
+event of failure, or so that the locally stored key can be deleted for
+extra security. Encryption keys can also be optionally protected with a
+*passphrase* for additional security. 
+
+The combination of encryption key location and optional passphrase is
+useful in several different security scenarios:
 
 * *Key stored locally, no passphrase*: the encrypted volume is
   decrypted and accessible when the system running. Protects "data at

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1375,9 +1375,9 @@ Managing Encrypted Volumes
 a new encrypted volume is created. This key is required to read and
 decrypt any data on the volume. 
 
-By default, %brand% stores encryption keys locally within the system
-settings so volumes can automatically decrypt when the system
-starts or when triggered by an authorized user.
+%brand% stores encryption keys on the system boot pool by default, so 
+encrypted pools can be automatically decrypted when the system starts,
+or when triggered by an authorized user.
 
 Encryption keys can also be downloaded. This is useful as a safety
 measure to allow key backup, to use the key for decryption on a different system in the

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1376,7 +1376,7 @@ a new encrypted volume is created. This key is required to read and
 decrypt any data on the volume. 
 
 By default, %brand% stores encryption keys locally within the system
- settings so volumes can automatically decrypt when the system
+settings so volumes can automatically decrypt when the system
 starts or when triggered by an authorized user.
 
 Encryption keys can also be downloaded. This is useful as a safety

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1377,7 +1377,7 @@ decrypt any data on the volume.
 
 By default, %brand% stores encryption keys locally within its system
  settings so volumes can automatically decrypt when the system
-start-up, or by authorized users.
+starts or when triggered by an authorized user.
 
 Encryption keys can also be downloaded. This is useful as a safety
 measure, to allow key backup, decryption on a different system in the

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1381,7 +1381,7 @@ starts or when triggered by an authorized user.
 
 Encryption keys can also be downloaded. This is useful as a safety
 measure to allow key backup, to use the key for decryption on a different system in the
-event of failure, or so that the locally stored key can be deleted for
+event of failure, or so the locally stored key can be deleted for
 extra security. Encryption keys can also be protected with a
 *passphrase* for additional security. 
 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1375,7 +1375,7 @@ Managing Encrypted Volumes
 a new encrypted volume is created. This key is required to read and
 decrypt any data on the volume. 
 
-By default, %brand% stores encryption keys locally within its system
+By default, %brand% stores encryption keys locally within the system
  settings so volumes can automatically decrypt when the system
 starts or when triggered by an authorized user.
 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1382,7 +1382,7 @@ starts or when triggered by an authorized user.
 Encryption keys can also be downloaded. This is useful as a safety
 measure, to allow key backup, decryption on a different system in the
 event of failure, or so that the locally stored key can be deleted for
-extra security. Encryption keys can also be optionally protected with a
+extra security. Encryption keys can also be protected with a
 *passphrase* for additional security. 
 
 The combination of encryption key location and optional passphrase is

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1376,7 +1376,8 @@ a new encrypted volume is created. This key is required to read and
 decrypt any data on the volume. 
 
 By default, %brand% stores encryption keys locally within its system
-settings, so that authorized users can easily login and decrypt volumes.
+settings, so that volumes can easily be decrypted automatically on system
+start-up, or by authorized users.
 
 Encryption keys can also be downloaded. This is useful as a safety
 measure, to allow key backup, decryption on a different system in the

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1376,7 +1376,7 @@ a new encrypted volume is created. This key is required to read and
 decrypt any data on the volume. 
 
 By default, %brand% stores encryption keys locally within its system
-settings, so that volumes can easily be decrypted automatically on system
+ settings so volumes can automatically decrypt when the system
 start-up, or by authorized users.
 
 Encryption keys can also be downloaded. This is useful as a safety

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -1380,7 +1380,7 @@ settings so volumes can automatically decrypt when the system
 starts or when triggered by an authorized user.
 
 Encryption keys can also be downloaded. This is useful as a safety
-measure, to allow key backup, decryption on a different system in the
+measure to allow key backup, to use the key for decryption on a different system in the
 event of failure, or so that the locally stored key can be deleted for
 extra security. Encryption keys can also be protected with a
 *passphrase* for additional security. 


### PR DESCRIPTION
This paragraph isnt easy to parse for a user.  Also it tends to mis-suggest key handling (it says it stores the key, but storing the key locally is actually a default+user choice, not a necessity, so the reader has to figure out this vs. next paragraph which is avoidable).

Refactor it (without changing its substance) to make it easier to read.