### PR TITLE
27878: Fix warning about L2ARC encryption

### DIFF
--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -236,9 +236,10 @@ a pool with encryption:
   including ZIL and SLOG, are encrypted if the underlying disks are
   encrypted. Swap data on disk is always encrypted.
 
-* Cache (L2ARC) drives are encrypted when the attached pool is
-  encrypted. Each individually attached Cache (L2ARC) drive adopts the
-  pool encryption when that pool is created.
+* All drives in an encrypted pool are encrypted, including L2ARC
+  (read cache) and SLOG (write cache). Drives added to an existing
+  encrypted pool are encrypted with the same method specified when
+  the pool was created.
 
 * At present, there is no automated method to encrypt an existing,
   unencrypted pool. Instead, the data must be backed up, the

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -236,9 +236,9 @@ a pool with encryption:
   including ZIL and SLOG, are encrypted if the underlying disks are
   encrypted. Swap data on disk is always encrypted.
 
-  .. warning:: Data stored in Cache (L2ARC) drives is not encrypted.
-     Do not use Cache (L2ARC) with encrypted pools.
-
+* Cache (L2ARC) drives are encrypted when the attached pool is
+  encrypted. Each individually attached Cache (L2ARC) drive adopts the
+  pool encryption when that pool is created.
 
 * At present, there is no automated method to encrypt an existing,
   unencrypted pool. Instead, the data must be backed up, the


### PR DESCRIPTION
Replace the warning with another bullet point explaining when attached L2ARC drives are encrypted.
HTML build test: no issues.