### PR TITLE
Note a correction

### DIFF
--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -333,7 +333,11 @@ These screen options have changed:
 * Disk temperature graphs have been added to
   :menuselection:`Reporting --> Disk`.
 
+Correction to documentation:
 
+* The section :ref:`Encryption` has been corrected to state that an
+  L2ARC cache device is always encrypted when its underlying pool is encrypted.
+  
 .. index:: Path and Name Lengths
 .. _Path and Name Lengths:
 


### PR DESCRIPTION
See https://redmine.ixsystems.com/issues/27878

Although Dru says to open a forum post, I do feel that insofar as the docs have previously misled users, and most users will not trawl the the forums (many will only rarely/never read them), the docs should say something because in effect this is "new information" for 11.2-REL, where the guidance contradicts previous guidance.  

It's good that the "encryption" section has been corrected, but a user who has their pool set up, might not think to read that section, they'll look for "new things" and not find that the previous guidance was wrong.

I think it can be done very briefly, and without a fuss. This is an attempt at doing so. Hoping it is acceptable.