### PR TITLE
Update M-Series BSG from review notes (except image changes):

### DIFF
--- a/userguide/conf.py
+++ b/userguide/conf.py
@@ -116,7 +116,7 @@ if tags.has('bsg-mseries'):
     project = brand + ' ' + six.u('M-Series Unified Storage Array')
     projtype = 'Basic Setup Guide'
     master_doc = 'bsg-mseries'
-    cover_pic = r'\vspace*{.1in}\hspace*{4in}\includegraphics[width=12in]{../../../images/tn_m_front.png}'
+    cover_pic = r'\vspace*{.1in}\hspace*{4in}\includegraphics[width=9in]{../../../images/tn_m_front.png}'
 
 if tags.has('bsg-es60'):
     brand = 'TrueNAS®' if six.PY3 else u'TrueNAS®'

--- a/userguide/snippets/mseries.rst
+++ b/userguide/snippets/mseries.rst
@@ -7,8 +7,8 @@
 M-Series Unified Storage Array
 ------------------------------
 
-The %brand% M-Series Unified Storage Array is a 4U, 24-bay, hybrid
-unified data storage array.
+The %brand% M-Series Unified Storage Array is a 4U, 24-bay, hybrid data
+storage array.
 
 
 #include snippets/perfect.rst
@@ -72,8 +72,13 @@ fault. The fault indicator is on during the initial power-on self-test
 
 
 The M-Series contains one or two storage controllers in an
-over-and-under configuration. The connectors and features on each
-storage controller are:
+over-and-under configuration:
+
+.. _m_back:
+
+.. figure:: images/tn_m_back.png
+   :width: 100%
+
 
 .. tabularcolumns:: |>{\RaggedRight}p{\dimexpr 0.5\linewidth-2\tabcolsep}
                     |>{\RaggedRight}p{\dimexpr 0.5\linewidth-2\tabcolsep}|
@@ -97,21 +102,13 @@ storage controller are:
    | 6: 10Gb Ethernet port                        | 12: Storage controller management port       |
    +----------------------------------------------+----------------------------------------------+
 
-**M-Series systems with only a single storage controller must be shut
-down and powered off before removing the controller or data loss will
-occur.**
 
 For remote management with IPMI, the 1 Gb Ethernet Out of Band
 management port (#3) must be connected to a network.
 
-
-.. _m_back:
-
-.. figure:: images/tn_m_back.png
-   :width: 100%
-
-   Back Panel
-
+**M-Series systems with only a single storage controller must be shut
+down and powered off before removing the controller or data loss will
+occur.**
 
 .. raw:: latex
 

--- a/userguide/snippets/userguide.rst
+++ b/userguide/snippets/userguide.rst
@@ -1,3 +1,4 @@
+
 .. index:: User Guide Location
 
 .. _User Guide:
@@ -9,4 +10,3 @@ The %brand% User Guide with complete configuration instructions is
 available by clicking :guilabel:`Guide` in the %brand% user interface
 or at
 `<https://support.ixsystems.com/truenasguide/truenas.html>`__.
-


### PR DESCRIPTION
25% reduction to title page image
Remove redundant word in section 1
Move table of storage controller connectors to after the back panel image.
Move single storage controller warning to after the back panel image.
Fix index entry that was erroneously visible.
PDF build testing: no issues.