### PR TITLE
The TrueNAS unit can remain on while the expansion shelf is connected.

### DIFF
--- a/userguide/snippets/es12.rst
+++ b/userguide/snippets/es12.rst
@@ -129,9 +129,6 @@ Connect Power Cords
 Connect SAS Cables
 ~~~~~~~~~~~~~~~~~~
 
-Shut down and power off the %brand% X-Series. Remove the X-Series
-power cables from the power outlets.
-
 Plug the ES12 power cords into power outlets.
 **Wait two minutes for the drives to start.**
 


### PR DESCRIPTION
- I removed the sentences that mentioned powering off the xseries as suggested by Bill. 
- Bill O'Hanlon reviewed this section and said the procedure is right and does not need to change other than removing those two sentences. 
- This is in response to https://redmine.ixsystems.com/issues/57294
