### PR TITLE
59397: Update entry for Domain Account Password in directoryservices.rst

### DIFF
--- a/userguide/directoryservices.rst
+++ b/userguide/directoryservices.rst
@@ -118,8 +118,8 @@ advanced options.
    |                          |               |          | input is entered.                                                                                                             |
    |                          |               |          |                                                                                                                               |
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
-   | Domain Account Password  | string        |          | Password for the Active Directory administrator account. This field is mandatory. :guilabel:`Save` will be inactive until     |
-   |                          |               |          | valid input is entered.                                                   .                                                   |
+   | Domain Account Password  | string        |          | Password for the Active Directory administrator account. Required the first time a domain is configured. Subsequent edits do  |
+   |                          |               |          | not require the password.                                                                                                     |
    |                          |               |          |                                                                                                                               |
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
    | Connectivity Check       | integer       |          | How often for the system to verify Active Directory services are functioning. Enter a number of seconds.                      |

--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -345,6 +345,11 @@ These screen options have changed:
 * The :guilabel:`MSDOSFS locale` drop-down menu has been added to
   :menuselection:`Storage --> Import Disk`.
 
+* The :guilabel:`Domain Account Password` field in
+  :menuselection:`Directory Services --> Active Directory`
+  has been reworked to only be required when configuring a domain for
+  the first time.
+
 * The :guilabel:`User Base` and :guilabel:`Group Base` fields have
   been removed from
   :menuselection:`Directory Services --> Active Directory --> Advanced Mode`.

--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -347,7 +347,7 @@ These screen options have changed:
 
 * The :guilabel:`Domain Account Password` field in
   :menuselection:`Directory Services --> Active Directory`
-  has been reworked to only be required when configuring a domain for
+  is only required when configuring a domain for
   the first time.
 
 * The :guilabel:`User Base` and :guilabel:`Group Base` fields have

--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -345,7 +345,7 @@ These screen options have changed:
 * The :guilabel:`MSDOSFS locale` drop-down menu has been added to
   :menuselection:`Storage --> Import Disk`.
 
-* The :guilabel:`Domain Account Password` field in
+* A :guilabel:`Domain Account Password` in
   :menuselection:`Directory Services --> Active Directory`
   is only required when configuring a domain for
   the first time.


### PR DESCRIPTION
Rework entry to indicate password is only required the first time a domain is configured.
Add entry in intro.rst to explain the change.
HTML build testing: no issues.

Change is new UI specific. No port to other branches is necessary.