### PR TITLE
60792: Update Certificate field in directoryservices.rst/AD section

### DIFF
--- a/userguide/directoryservices.rst
+++ b/userguide/directoryservices.rst
@@ -133,12 +133,12 @@ advanced options.
    | Encryption Mode          | drop-down     | ✓        | Choices are *Off*, *SSL*, or *TLS*. Refer to `SSL vs. TLS                                                                     |
    |                          | menu          |          | <https://www.globalsign.com/en/blog/ssl-vs-tls-difference/>`__ for more information on SSL and TLS.                           |
    |                          |               |          |                                                                                                                               |
-   |                          |               |          |                                                                                                                               |
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
-   | Certificate              | drop-down menu| ✓        | Select the certificate of the Active Directory server if SSL connections are used. If a certificate does not exist, create    |
-   |                          |               |          | a :ref:`Certificate Authority <CAs>`, then create a certificate on the Active Directory server. Import the certificate to the |
-   |                          |               |          | %brand% system using the :ref:`Certificates` menu. Choose the blank entry and click :guilabel:`SAVE` to clear                 |
-   |                          |               |          | a saved certificate from the AD configuration.                                                                                |
+   | Certificate              | drop-down     | ✓        | Select the certificate of the Active Directory server if SSL connections are used. If a certificate does not exist, create    |
+   |                          | menu          |          | a :ref:`Certificate Authority <CAs>`, then create a certificate on the Active Directory server. Import the certificate to the |
+   |                          |               |          | %brand% system using the :ref:`Certificates` menu.                                                                            |
+   |                          |               |          |                                                                                                                               |
+   |                          |               |          | Choose the blank entry and click :guilabel:`SAVE` to clear a saved certificate from the AD configuration.                     |
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
    | Verbose logging          | checkbox      | ✓        | Set to log attempts to join the domain to :file:`/var/log/messages`.                                                          |
    |                          |               |          |                                                                                                                               |

--- a/userguide/directoryservices.rst
+++ b/userguide/directoryservices.rst
@@ -134,11 +134,11 @@ advanced options.
    |                          | menu          |          | <https://www.globalsign.com/en/blog/ssl-vs-tls-difference/>`__ for more information on SSL and TLS.                           |
    |                          |               |          |                                                                                                                               |
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
-   | Certificate              | drop-down     | ✓        | Select the certificate of the Active Directory server if SSL connections are used. If a certificate does not exist, create    |
-   |                          | menu          |          | a :ref:`Certificate Authority <CAs>`, then create a certificate on the Active Directory server. Import the certificate to the |
+   | Certificate              | drop-down     | ✓        | Select the Active Directory server certificate if SSL connections are used. If a certificate does not exist, create a         |
+   |                          | menu          |          | :ref:`Certificate Authority <CAs>`, then create a certificate on the Active Directory server. Import the certificate to the   |
    |                          |               |          | %brand% system using the :ref:`Certificates` menu.                                                                            |
    |                          |               |          |                                                                                                                               |
-   |                          |               |          | Choose the blank entry and click :guilabel:`SAVE` to clear a saved certificate from the AD configuration.                     |
+   |                          |               |          | To clear a saved certificate, choose the blank entry and click :guilabel:`SAVE`.                                              |
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
    | Verbose logging          | checkbox      | ✓        | Set to log attempts to join the domain to :file:`/var/log/messages`.                                                          |
    |                          |               |          |                                                                                                                               |

--- a/userguide/directoryservices.rst
+++ b/userguide/directoryservices.rst
@@ -137,8 +137,8 @@ advanced options.
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
    | Certificate              | drop-down menu| ✓        | Select the certificate of the Active Directory server if SSL connections are used. If a certificate does not exist, create    |
    |                          |               |          | a :ref:`Certificate Authority <CAs>`, then create a certificate on the Active Directory server. Import the certificate to the |
-   |                          |               |          | %brand% system using the :ref:`Certificates` menu.                                                                            |
-   |                          |               |          |                                                                                                                               |
+   |                          |               |          | %brand% system using the :ref:`Certificates` menu. Choose the blank entry and click :guilabel:`SAVE` to clear                 |
+   |                          |               |          | a saved certificate from the AD configuration.                                                                                |
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
    | Verbose logging          | checkbox      | ✓        | Set to log attempts to join the domain to :file:`/var/log/messages`.                                                          |
    |                          |               |          |                                                                                                                               |


### PR DESCRIPTION
- Update entry to indicate choosing the blank option clears a saved certificate.
- Determine this is fixing a bug to bring feature parity with old UI. No intro.rst entry needed.
- This text applies to the legacy ui documented in both the master and freenas/11.1-stable branches. PR will be ported to each branch.
- HTML build test: no issues.