### PR TITLE
68473: Add note about tap interfaces and virtual machines.

### DIFF
--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -235,6 +235,10 @@ This software has been added or updated:
   Upgrades will continue to use the :command:`csh` shell as the default
   root shell.
 
+* `ifconfig <https://www.freebsd.org/cgi/man.cgi?query=ifconfig>`__ tap
+  interface descriptions now show the name of the attached virtual
+  machine.
+
 * `xattr <https://github.com/xattr/xattr>`__ has been added to the base
   system and can be used to modify file extended attributes from the
   command line. Type :command:`xattr -h` to view the available options.

--- a/userguide/virtualmachines.rst
+++ b/userguide/virtualmachines.rst
@@ -350,6 +350,11 @@ physical interface to associate with the VM.
 Set a :guilabel:`Device Order` number to determine the boot order of
 this device. A lower number means a higher boot priority.
 
+.. tip:: To check which interface is attached to a VM, start the VM
+   and go to the :ref:`Shell`. Type :command:`ifconfig` and find the
+   `tap <https://en.wikipedia.org/wiki/TUN/TAP>`__ interface that shows
+   the name of the VM in the description.
+
 
 .. _vms-disk-device:
 


### PR DESCRIPTION
- Add entry to intro.rst about the new functionality of ifconfig.
- Add tip box to the virtual machines/network interfaces section explaining how to see which interface is associated with a VM.
- HTML build test: no issues.
- Changes need a port to master branch.