### PR TITLE
Copyright year substitution:

### DIFF
--- a/userguide/conf.py
+++ b/userguide/conf.py
@@ -175,6 +175,7 @@ if tags.has('bsg-es60'):
 # roles for text replacement
 rst_prolog = u'''
 .. |web-ui| replace:: web interface
+.. |copyright-year| replace:: 2019
 '''
 
 # The name of the Pygments (syntax highlighting) style to use.

--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -1,4 +1,4 @@
-%brand% is © 2011-2019 iXsystems
+%brand% is © 2011-|copyright-year| iXsystems
 
 %brand% and the %brand% logo are registered trademarks of iXsystems
 
@@ -9,7 +9,7 @@ system.
 
 Version |release|
 
-Copyright © 2011-2019
+Copyright © 2011-|copyright-year|
 `iXsystems <https://www.ixsystems.com/>`__
 
 

--- a/userguide/snippets/copyright.rst
+++ b/userguide/snippets/copyright.rst
@@ -1,3 +1,3 @@
-Copyright © 2019 iXsystems, Inc. All rights reserved.
+Copyright © |copyright-year| iXsystems, Inc. All rights reserved.
 
 All trademarks are the property of their respective owners.

--- a/userguide/tn_intro.rst
+++ b/userguide/tn_intro.rst
@@ -1,4 +1,4 @@
-Copyright iXsystems 2011-2019
+Copyright iXsystems 2011-|copyright-year|
 
 
 .. raw:: latex


### PR DESCRIPTION
Define new |copyright-year| substitution in conf.py and use it where necessary in the FreeNAS/TrueNAS guides.

FreeNAS/TrueNAS HTML test: no issues.