### PR TITLE
62469: Expand note about modifying plugin jails a little

### DIFF
--- a/userguide/plugins.rst
+++ b/userguide/plugins.rst
@@ -96,9 +96,12 @@ after a successful install. Installed plugins appear in the
 :menuselection:`Plugins --> Installed`
 page as shown in :numref:`Figure %s <view_installed_plugins_fig>`.
 
-.. tip:: Installed plugins are also added to the
+.. note:: Plugins are also added to
    :menuselection:`Jails`
-   page. This page is also used to manage installed software.
+   as a *pluginv2* jail. This jail type is asjustable just like a
+   standard jail, except the *UUID* cannot be altered.
+   See :ref:`Managing Jails` for more details about modifying plugin
+   jails.
 
 
 .. _view_installed_plugins_fig:


### PR DESCRIPTION
- Include reference to Managing Jails section.
- Note that pluginv2 jails cannot have their UUID changed.
- HTML build test: no issues.
- Specific to new UI: no ports to other branches necessary.