### PR TITLE
Fix building TrueNAS guide

### DIFF
--- a/userguide/directoryservices.rst
+++ b/userguide/directoryservices.rst
@@ -213,8 +213,8 @@ advanced options.
    #endif freenas
    #ifdef truenas
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
-   | NetBIOS Name (This Node) | string        | ✓        | Limited to 15 characters. Automatically populated with the %brand% system original hostname. This **must** be different from  |
-   |                          |               |          | the *Workgroup* name.                                                                                                         |
+   | NetBIOS Name (This Node) | string        | ✓        | Limited to 15 characters. Automatically populated with the %brand% system original hostname. This **must** be                 |
+   |                          |               |          | different from the *Workgroup* name.                                                                                          |
    |                          |               |          |                                                                                                                               |
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
    | NetBIOS Name (Node B)    | string        | ✓        | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the standby node.                         |

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -182,7 +182,9 @@ settings in the General tab:
    +----------------------+----------------+--------------------------------------------------------------------------------------------------------------------------+
    | Language             | drop-down menu | Select a language. View the status of a language in the                                                                  |
    |                      |                | `webui GitHub repository <https://github.com/freenas/webui/tree/master/src/assets/i18n>`__                               |
+#ifdef freenas
    |                      |                | Refer to :ref:`Contributing to %brand%` for more information about supported languages.                                  |
+#endif freenas
    |                      |                |                                                                                                                          |
    +----------------------+----------------+--------------------------------------------------------------------------------------------------------------------------+
    | Console Keyboard Map | drop-down menu | Select a keyboard layout.                                                                                                |
@@ -546,7 +548,7 @@ are shown as in :numref:`Figure %s <mirror_boot_status_fig>`.
 .. figure:: images/system-boot-mirror.png
 
    Viewing the Status of a Mirrored Boot Device
-#endif freenas
+
 
 
 .. _Advanced:
@@ -2700,8 +2702,8 @@ additional fields to the output to help with failover troubleshooting:
 :samp:`CriticalGroup{n}` and :samp:`Interlink`.
 
 If both nodes reboot simultaneously, the GELI passphrase for an
-:ref:`encrypted <Encryption>` pool must be entered at the |web-ui|
-login screen.
+:ref:`encrypted <Managing Encrypted Pools>` pool must be entered at the
+|web-ui| login screen.
 
 
 #endif truenas

--- a/userguide/truenas.rst
+++ b/userguide/truenas.rst
@@ -12,13 +12,12 @@
    tasks
    network
    storage
-   directoryservice
+   directoryservices
    sharing
    services
    tn_vcenter
    tn_cinder
    reporting
-   wizard
    tn_options
    zfsprimer
    tn_hardware


### PR DESCRIPTION
Fix the blockers that were preventing an HTML build of the TrueNAS guide from completing:
 - directoryservices.rst name mismatch.
 - Removal of wizard.rst from the angular guide.
 - Not enough space for a %brand% replacement inside a table.

 Fixed the TrueNAS build warnings in system.rst:
 - Remove additional #endif freenas that had no starting definition.
 - Fix up a reference point that is not included in the Truenas guide.

`make TAG=truenas html` works now, but there are 19 warnings generated.