### PR TITLE
Add entry reflecting l2arc size reporting change to intro.

### DIFF
--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -361,6 +361,10 @@ U2
 * The :guilabel:`Enable SMB1 support` checkbox has been added to
   :menuselection:`Services --> SMB`.
 
+* The :guilabel:`ARC Size` graph in
+  :menuselection:`Reporting` now shows the compressed physical L2ARC
+  size.
+
 
 .. index:: Path and Name Lengths
 .. _Path and Name Lengths:


### PR DESCRIPTION
Investigation of storage.rst and reporting.rst shows no changes needed.
Investigation of angulargui branch and 11.1-stable branch shows change not reflected in either FreeNAS version.
HTML build test: no issues.