### PR TITLE
FreeNAS Forum suggestion: Add example of exiting iocage jail console

### DIFF
--- a/userguide/jails.rst
+++ b/userguide/jails.rst
@@ -1506,6 +1506,13 @@ To open the console in the started jail, use :command:`iocage console`
    Edit /etc/motd to change this login announcement.
    root@examplejail:~ #
 
+Exit the jail console with :command:`logout`:
+
+.. code-block:: none
+
+   root@examplejail:~ # logout
+   [root@freenas ~]#
+
 Jails are shut down with :command:`iocage stop`:
 
 .. code-block:: none


### PR DESCRIPTION
Doc queue item 28 (no Redmine ticket): https://forums.freenas.org/index.php?threads/there-is-something-missing-in-the-documentation-that-might-make-sense-to-mention.72480/#post-501869
Add simple example of using logout to exit a jail console.
HTML build test: no issues.