### PR TITLE
33141: Add entry to intro about the removed collectd IPMI plugin.

### DIFF
--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -410,6 +410,9 @@ U2
   :menuselection:`Reporting`
   now shows the compressed physical L2ARC size.
 
+* :file:`usr/local/lib/collectd/ipmi.so` and the **openipmi** package
+  were removed to disable the broken collectd IPMI plugin.
+
 
 .. _Path and Name Lengths:
 


### PR DESCRIPTION
- Investigate the rest of the guide and did not find any other relevant text.
- HTML build test: no issues.