### PR TITLE
50321: Add text about new NAA column in Sharing/iSCSI/Extents:

### DIFF
--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -423,7 +423,7 @@ U2
   :menuselection:`Dashboard`
   now change color to reflect the current pool status.
 
-* A :guilabel:`NAA` column has been added to
+* An :guilabel:`NAA` column has been added to
   :menuselection:`Sharing --> Block (iSCSI) --> Extents`.
 
 

--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -414,6 +414,9 @@ U2
   :menuselection:`Dashboard`
   now change color to reflect the current pool status.
 
+* A :guilabel:`NAA` column has been added to
+  :menuselection:`Sharing --> Block (iSCSI) --> Extents`.
+
 
 .. _Path and Name Lengths:
 

--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -2264,7 +2264,7 @@ file to be created is appended to the pool or dataset name.**
    +--------------------+----------------+----------------------------------------------------------------------------------------------------------------------+
 
 
-New extents are added to
+New extents have been added to
 :menuselection:`Sharing --> Block (iSCSI) --> Extents`.
 The associated :guilabel:`Serial` and Network Address Authority
 (:guilabel:`NAA`) are shown along with the extent name.

--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -2264,6 +2264,12 @@ file to be created is appended to the pool or dataset name.**
    +--------------------+----------------+----------------------------------------------------------------------------------------------------------------------+
 
 
+New extents are added to
+:menuselection:`Sharing --> Block (iSCSI) --> Extents`.
+The associated :guilabel:`Serial` and Network Address Authority
+(:guilabel:`NAA`) are shown along with the extent name.
+
+
 .. _Associated Targets:
 
 Associated Targets


### PR DESCRIPTION
- Add entry in intro.rst/U2 section.
- Add a bit of text at the end of the sharing.rst/Block (iSCSI)/Extents section
  explaining where the NAA is shown.
- HTML build test: no issues