### PR TITLE
45398: Add syslog-ng alert

### DIFF
--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -374,6 +374,11 @@ U2
   :file:`usr/local/lib/collectd/ipmi.so` were removed to disable the
   non-functional collectd IPMI plugin.
 
+* An :ref:`Alert` for
+  `syslog-ng <https://www.freebsd.org/cgi/man.cgi?query=syslog-ng>`__
+  stopping has been added to
+  :menuselection:`System --> Alerts`.
+
 
 .. index:: Path and Name Lengths
 .. _Path and Name Lengths:

--- a/userguide/snippets/alertevents.rst
+++ b/userguide/snippets/alertevents.rst
@@ -67,6 +67,9 @@ Some of the conditions that trigger an alert include:
 
 #endif freenas
 
+* `syslog-ng(8) <https://www.freebsd.org/cgi/man.cgi?query=syslog-ng>`__
+  is not running
+
 * the system is unable to bind to the :guilabel:`WebGUI IPv4 Address`
   set in
   :menuselection:`System --> General`


### PR DESCRIPTION
Add entries in intro.rst and snippets/alertevents.rst for the new alert.
HTML build test: no issues.