### PR TITLE
Doc Queue Item 1: Add AHCI disk recommendation for VMs with a Windows OS

### DIFF
--- a/userguide/virtualmachines.rst
+++ b/userguide/virtualmachines.rst
@@ -379,6 +379,7 @@ Open the drop-down menu to select a created :guilabel:`Zvol`, then set
 the disk :guilabel:`Mode`:
 
 * *AHCI* emulates an AHCI hard disk for best software compatibility.
+  This is recommended for VMs using a Windows operating system.
 
 * *VirtIO* uses paravirtualized drivers and can provide better
   performance, but requires the operating system installed in the VM to

--- a/userguide/virtualmachines.rst
+++ b/userguide/virtualmachines.rst
@@ -379,7 +379,7 @@ Open the drop-down menu to select a created :guilabel:`Zvol`, then set
 the disk :guilabel:`Mode`:
 
 * *AHCI* emulates an AHCI hard disk for best software compatibility.
-  This is recommended for VMs using a Windows operating system.
+  This is recommended for Windows VMs.
 
 * *VirtIO* uses paravirtualized drivers and can provide better
   performance, but requires the operating system installed in the VM to


### PR DESCRIPTION
Investigate notes in [27301](https://redmine.ixsystems.com/issues/23701#note-15), [28580](https://redmine.ixsystems.com/issues/28580#note-3), [23990](https://redmine.ixsystems.com/issues/23990#note-9), and [23794](https://redmine.ixsystems.com/issues/23794#note-18) and add a short recommendation to use AHCI disks for VMs using a Windows OS.

HTML build test: no issues.