### PR TITLE
62712: Add entry to intro.rst for rename of VNC "Wait to Boot" option.

### DIFF
--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -452,6 +452,10 @@ U2
   stopping has been added to
   :menuselection:`System --> Alert Settings`.
 
+* The :guilabel:`Wait to Boot` field in
+  :menuselection:`Virtual Machines --> Devices --> VNC Device --> Edit`
+  has been renamed to :guilabel:`Delay VM Boot until VNC Connects`.
+
 
 .. _Path and Name Lengths:
 


### PR DESCRIPTION
HTML build test: no issues.
Rename not present in legacy UI. No master PR needed.
Searched angulargui branch docs: no remaining instances of "Wait to Boot" option found.