### PR TITLE
58392 (11.2-U3): Add ZFS Feature Flags section and new references to this section

### DIFF
--- a/userguide/install.rst
+++ b/userguide/install.rst
@@ -495,11 +495,11 @@ Be aware of these caveats **before** attempting an upgrade to
 * **Warning: upgrading the ZFS pool can make it impossible to go back
   to a previous version.** For this reason, the update process does
   not automatically upgrade the ZFS pool, though the :ref:`Alert`
-  system shows when newer feature flags are available for a pool.
-  Unless a new feature flag is needed, it is safe to leave the pool at
-  the current version and uncheck the alert. If the pool is upgraded,
-  it will not be possible to boot into a previous version that does
-  not support the newer feature flags.
+  system shows when newer :ref:`ZFS Feature Flags` are available for a
+  pool. Unless a new feature flag is needed, it is safe to leave the
+  pool at the current version and uncheck the alert. If the pool is
+  upgraded, it will not be possible to boot into a previous version that
+  does not support the newer feature flags.
 
 * Upgrading the firmware of Broadcom SAS HBAs to the latest version is
   recommended.

--- a/userguide/snippets/alertevents.rst
+++ b/userguide/snippets/alertevents.rst
@@ -80,8 +80,8 @@ Some of the conditions that trigger an alert include:
 * used space on a pool, dataset, or zvol goes over 80%; the alert
   goes red at 95%
 
-* new OpenZFS feature flags are available for the pool; this alert can
-  be adjusted in :ref:`Alert Settings` if a pool upgrade is not
+* new :ref:`ZFS Feature Flags` are available for the pool; this alert
+  can be adjusted in :ref:`Alert Settings` if a pool upgrade is not
   desired at present
 
 * a new update is available

--- a/userguide/snippets/upgradingazfspool.rst
+++ b/userguide/snippets/upgradingazfspool.rst
@@ -13,7 +13,7 @@ first:
 * the pool upgrade is a one-way street, meaning that
   **if you change your mind you cannot go back to an earlier ZFS
   version or downgrade to an earlier version of the software that
-  does not support those feature flags.**
+  does not support those ZFS features.**
 
 * before performing any operation that may affect the data on a
   storage disk, **always back up all data first and verify the
@@ -25,9 +25,9 @@ first:
   the possibility of reverting to an earlier version of %brand% or
   repurposing the disks in another operating system that supports ZFS
   is desired. It is not necessary to upgrade the pool unless the end
-  user has a specific need for the newer ZFS feature flags. If a pool
-  is upgraded to the latest feature flags, it will not be possible to
-  import that pool into another operating system that does not yet
+  user has a specific need for the newer :ref:`ZFS Feature Flags`. If a
+  pool is upgraded to the latest feature flags, it will not be possible
+  to import that pool into another operating system that does not yet
   support those feature flags.
 
 To perform the ZFS pool upgrade, go to

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -199,9 +199,10 @@ deduplication has been enabled, the mountpoint path, and any comments
 entered for the pool.
 
 There is an option to :guilabel:`Upgrade Pool`. This upgrades the
-pool to the latest ZFS features, as described in
-:ref:`Upgrading a ZFS Pool`. This button does not appear
-if the pool is running the latest version of feature flags.
+pool to the latest :ref:`ZFS Feature Flags`. See the warnings in
+:ref:`Upgrading a ZFS Pool` before selecting this option. This button
+does not appear when the pool is running the latest version of the
+feature flags.
 
 .. _zfs_vol_fig:
 

--- a/userguide/zfsprimer.rst
+++ b/userguide/zfsprimer.rst
@@ -10,21 +10,15 @@ to provide features not available in traditional UNIX filesystems. It
 was originally developed at Sun with the intent to open source the
 filesystem so that it could be ported to other operating systems.
 After the Oracle acquisition of Sun, some of the original ZFS
-engineers founded `OpenZFS <http://open-zfs.org/wiki/Main_Page>`__
+engineers founded
+`OpenZFS <http://open-zfs.org/wiki/Main_Page>`__
 to provide continued, collaborative development of the open
-source version. To differentiate itself from Oracle ZFS version
-numbers, OpenZFS uses feature flags. Feature flags are used to tag
-features with unique names in order to provide portability between
-OpenZFS implementations running on different platforms, as long as all
-of the feature flags enabled on the ZFS pool are supported by both
-platforms. %brand% uses OpenZFS and each new version of %brand% keeps
-up-to-date with the latest feature flags and OpenZFS bug fixes.
+source version.
 
 Here is an overview of the features provided by ZFS:
 
 **ZFS is a transactional, Copy-On-Write**
-`(COW)
-<https://en.wikipedia.org/wiki/ZFS#Copy-on-write_transactional_model>`__
+`(COW) <https://en.wikipedia.org/wiki/ZFS#Copy-on-write_transactional_model>`__
 filesystem. For each write request, a copy is made of the associated
 disk blocks and all changes are made to the copy rather than to the
 original blocks. When the write is complete, all block pointers are
@@ -248,6 +242,7 @@ suited to the specific storage requirements:
    :ref:`Periodic Snapshot Tasks` and :ref:`Replication Tasks` to use
    replicated ZFS snapshots as part of a backup strategy.
 
+
 **ZFS manages devices**. When an individual drive in a mirror or
 RAIDZ fails and is replaced by the user, ZFS adds the replacement
 device to the vdev and copies redundant data to it in a process called
@@ -306,3 +301,23 @@ These resources are also useful for reference:
 
 * `The Zettabyte Filesystem
   <https://www.youtube.com/watch?v=ptY6-K78McY>`__
+
+
+.. index:: ZFS Feature Flags
+.. _ZFS Feature Flags:
+
+ZFS Feature Flags
+~~~~~~~~~~~~~~~~~
+
+To differentiate itself from Oracle ZFS version numbers, OpenZFS uses
+feature flags. Feature flags are used to tag features with unique names
+to provide portability between OpenZFS implementations running on
+different platforms, as long as all of the feature flags enabled on the
+ZFS pool are supported by both platforms. %brand% uses OpenZFS and each
+new version of %brand% keeps up-to-date with the latest feature flags
+and OpenZFS bug fixes.
+
+See
+`zpool-features(7) <https://www.freebsd.org/cgi/man.cgi?query=zpool-features>`__
+for a complete listing of all OpenZFS feature flags available on FreeBSD.
+


### PR DESCRIPTION
- Rework text about OpenZFS feature flags into a new subsection of the ZFS Primer.
- Add a link to zpool-features(7).
- Add references to this new section where needed throughout the guide.