### PR TITLE
27864 (TrueNAS 11.2-U3): Add instruction to use physical interface IP addressses only w…

### DIFF
--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -1781,8 +1781,8 @@ link :guilabel:`Add extra Portal IP`.
    |                | menu         | address of *0.0.0.0* (any interface).                                           |
    |                |              |                                                                                 |
 #ifdef truenas
-   |                |              | Choose only physical interface IP addresses when configuring iSCSI ALUA.        |
-   |                |              |                                                                                 |
+   |                |              | Choose only physical interface IP addresses when configuring iSCSI ALUA. Do not |
+   |                |              | use Virtual IP addresses with an ALUA configuration.                            |
 #endif truenas
    +----------------+--------------+---------------------------------------------------------------------------------+
    | Port           | integer      | TCP port used to access the iSCSI target. Default is *3260*.                    |

--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -1780,6 +1780,10 @@ link :guilabel:`Add extra Portal IP`.
    | IP address     | drop-down    | Select the IPv4 or IPv6 address associated with an interface or the wildcard    |
    |                | menu         | address of *0.0.0.0* (any interface).                                           |
    |                |              |                                                                                 |
+#ifdef truenas
+   |                |              | Choose only physical interface IP addresses when configuring iSCSI ALUA.        |
+   |                |              |                                                                                 |
+#endif truenas
    +----------------+--------------+---------------------------------------------------------------------------------+
    | Port           | integer      | TCP port used to access the iSCSI target. Default is *3260*.                    |
    |                |              |                                                                                 |


### PR DESCRIPTION
…ith iSCSI ALUA.

TrueNAS guide build testing: no issues.