### PR TITLE
75675: Add "Host" field to TFTP Configuration Options table:

### DIFF
--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -497,6 +497,9 @@ U3
   :guilabel:`shadow_copy_test` object in
   :menuselection:`Sharing --> Windows (SMB) Shares --> ADD --> ADVANCED MODE`.
 
+* The :guilabel:`Host` field has been added to
+  :menuselection:`Services --> TFTP`.
+
 
 .. _Path and Name Lengths:
 

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1884,7 +1884,10 @@ available options.
    | Allow New Files  | checkbox      | Set when network devices need to send files to the system. For example, to back up their configuration.                  |
    |                  |               |                                                                                                                          |
    +------------------+---------------+--------------------------------------------------------------------------------------------------------------------------+
-   | Port             | integer       | Enter a UDP port to listen for TFTP requests, *69* by default.                                                           |
+   | Host             | IP address    | The default host to use for TFTP transfers. Enter an IP address. Example: *192.0.2.1*.                                   |
+   |                  |               |                                                                                                                          |
+   +------------------+---------------+--------------------------------------------------------------------------------------------------------------------------+
+   | Port             | integer       | The UDP port number that listens for TFTP requests. Example: *8050*.                                                     |
    |                  |               |                                                                                                                          |
    +------------------+---------------+--------------------------------------------------------------------------------------------------------------------------+
    | Username         | drop-down     | Select the account to use for TFTP requests. This account must have permission to the :guilabel:`Directory`.             |


### PR DESCRIPTION
Also sync up "Port" field description with updated help text.
HTML build test: no issues