### PR TITLE
Fix broken arrow replacement for |menuselection|

### DIFF
--- a/userguide/Makefile
+++ b/userguide/Makefile
@@ -73,6 +73,8 @@ html:	require preproc
 	@sed -i '' -e 's%%▶%g' $(PREPROCDIR)/$(BUILDDIR)/html/*.html
 	@sed -i '' -e 's%%🕓%g' $(PREPROCDIR)/$(BUILDDIR)/html/*.html
 	@sed -i '' -e 's%%%g' $(PREPROCDIR)/$(BUILDDIR)/html/*.html
+        # adjust |menuselection| arrow
+	@sed -i '' -e 's%‣%➞%g' $(PREPROCDIR)/$(BUILDDIR)/html/*.html
 	@echo
 	@echo "Build finished. The HTML index page is $(PREPROCDIR)/$(BUILDDIR)/html/$(TAG).html"
 

--- a/userguide/conf.py
+++ b/userguide/conf.py
@@ -182,40 +182,6 @@ rst_prolog = u'''
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
-# -- Option to change :menuselection: arrow -----------------------------
-
-from docutils import nodes, utils
-from docutils.parsers.rst import roles
-from sphinx.roles import _amp_re
-
-def patched_menusel_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
-    text = utils.unescape(text)
-    if typ == 'menuselection':
-        text = text.replace('-->', u'\u2192') # Here is the patch
-
-    spans = _amp_re.split(text)
-
-    node = nodes.literal(rawtext=rawtext)
-    for i, span in enumerate(spans):
-        span = span.replace('&&', '&')
-        if i == 0:
-            if len(span) > 0:
-                textnode = nodes.Text(span)
-                node += textnode
-            continue
-        accel_node = nodes.inline()
-        letter_node = nodes.Text(span[0])
-        accel_node += letter_node
-        accel_node['classes'].append('accelerator')
-        node += accel_node
-        textnode = nodes.Text(span[1:])
-        node += textnode
-
-    node['classes'].append(typ)
-    return [node], []
-
-# Use 'patched_menusel_role' function for processing the 'menuselection' role
-roles.register_local_role("menuselection", patched_menusel_role)
 
 rst_prolog = u'''
 .. |alert-icon-error| replace:: 


### PR DESCRIPTION
Removed broken patch from conf.py and add replacement to Makefile.
HTML build testing: no issues.
No adjustment to PDF building is necessary