### PR TITLE
Work with Support to refine SED docs

### DIFF
--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -724,6 +724,7 @@ For those who wish to see which checks are performed, the autotune
 script is located in :file:`/usr/local/bin/autotune`.
 #endif truenas
 
+
 .. index:: Self-Encrypting Drives
 .. _Self-Encrypting Drives:
 
@@ -732,7 +733,7 @@ Self-Encrypting Drives
 
 %brand% version 11.1-U5 introduced Self-Encrypting Drive (SED) support.
 
-Three types of SED devices are supported:
+Three types of SED are supported:
 
 * Legacy interface for older ATA devices. **Not recommended for
   security-critical environments**
@@ -743,86 +744,153 @@ Three types of SED devices are supported:
 * TCG Enterprise standard for newer enterprise-grade SAS devices
 
 The %brand% middleware implements the security capabilities of
-`camcontrol <https://www.freebsd.org/cgi/man.cgi?query=camcontrol>`__ (for
-legacy devices) and `sedutil-cli <https://www.mankier.com/8/sedutil-cli>`__
-(for TCG devices). When managing SED devices from the command line, it is
-important to use :command:`sedutil-cli` rather than camcontrol
-to access the full capabilities of the device. %brand% provides the
-:command:`sedhelper` wrapper script to ease SED device administration from
-the command line.
+`camcontrol <https://www.freebsd.org/cgi/man.cgi?query=camcontrol>`__
+for legacy devices and
+`sedutil-cli <https://www.mankier.com/8/sedutil-cli>`__
+for TCG devices. When managing a SED from the command line, it is
+important to use :command:`sedutil-cli` rather than camcontrol to access
+the full capabilities of the device. %brand% provides the
+:command:`sedhelper` wrapper script to ease SED administration from the
+command line.
 
-By default, SED devices are not locked until the administrator takes
-ownership of them. This is done by explicitly configuring a global or
-per-device password in the %brand% |web-ui| and adding the password to
-the SED devices.
+By default, SED are not locked until the administrator takes ownership
+of them. This is done by explicitly configuring a global or per-device
+password in the %brand% |web-ui| and adding the password to the SEDs.
 
-Once configured, the system automatically unlocks all SEDs during the boot
-process, without requiring manual intervention. This allows a pool to
-contain a mix of SED and non-SED devices.
+A password-protected SED protects the data stored on the device
+when the device is physically removed from the %brand% system. This
+allows secure disposal of the device without having to first wipe its
+contents. If the device is instead removed to be repurposed on another
+system, it can only be unlocked if the password is known.
 
-A password-protected SED device protects the data stored on the device
-when the device is physically removed from the %brand% system. This allows
-secure disposal of the device without having to first wipe its contents.
-If the device is instead removed to be repurposed on another system, it
-can only be unlocked if the password is known.
 
-.. warning:: It is important to remember the password! Without it, the
-   device is unlockable and its data remains unavailable. While it is
-   possible to specify the PSID number on the label of the device with
-   the :command:`sedutil-cli` command, doing so will erase the contents
-   of the device rather than unlock it. Always record SED passwords
-   whenever they are configured or modified and store them in a safe
-   place!
+.. _Deploying SEDs:
 
-When SED devices are detected during system boot, the middleware checks
-for global and device-specific passwords. Devices with their own password
-are unlocked with their password and any remaining devices, without a
-device-specific password, are unlocked using the global password.
+Deploying SEDs
+^^^^^^^^^^^^^^
 
-To configure a global password, go to :menuselection:`System -->
-Advanced --> SED Password` and enter the password. Recording the
-password and storing it in a safe place is recommended.
-
-To determine which devices support SED and their device names:
-
-.. code-block:: none
-
- sedutil-cli --scan
-
-In the results:
+To determine which devices support SED and their device names, go to the
+:menuselection:`Shell`
+and enter :command:`sedutil-cli --scan`. In the results:
 
 * **no** indicates a non-SED device
 * **1** indicates a legacy TCG OPAL 1 device
 * **2** indicates a modern TCG OPAL 2 device
 * **E** indicates a TCG Enterprise device
 
-To specify a password for a device, go to
-:menuselection:`Storage --> View Disks`. Highlight the device name for
-the confirmed SED device and click :guilabel:`Edit`. Enter and confirm
-the password in the :guilabel:`Password for SED` and
+Example:
+
+.. code-block:: none
+
+   root@truenas1:~ # sedutil-cli --scan
+   Scanning for Opal compliant disks
+   /dev/ada0  No  32GB SATA Flash Drive SFDK003L
+   /dev/ada1  No  32GB SATA Flash Drive SFDK003L
+   /dev/da0   No  HGST    HUS726020AL4210  A7J0
+   /dev/da1   No  HGST    HUS726020AL4210  A7J0
+   /dev/da10    E WDC     WUSTR1519ASS201  B925
+   /dev/da11    E WDC     WUSTR1519ASS201  B925
+
+
+%brand% supports setting a global password for all detected SEDs or
+setting individual passwords for each SED. Using a global password for
+all SEDs is strongly recommended to simplify deployment and avoid
+physically maintaining separate passwords for each SED.
+
+
+**Setting a global password for SEDs**
+
+Go to
+:menuselection:`System --> Advanced --> SED Password`
+and enter the password. **Record this password and store it in a safe
+place!**
+
+Now the SEDs must be configured with this password. Go to the
+:menuselection:`Shell`
+and enter :samp:`sedhelper setup {password}`, where *password* is the
+global password entered in
+:menuselection:`System --> Advanced --> SED Password`.
+
+:command:`sedhelper` ensures that all detected SEDs are properly
+configured to use the provided password. Example:
+
+.. code-block:: none
+
+   root@truenas1:~ # sedhelper setup abcd1234
+   da9			[OK]
+   da10			[OK]
+   da11			[OK]
+
+
+Rerun :samp:`sedhelper setup {password}` every time a new SED is placed
+in the system to apply the global password to the new SED.
+
+
+**Creating separate passwords for each SED**
+
+Go to
+:menuselection:`Storage --> View Disks`.
+Click |ui-options| for the confirmed SED, then :guilabel:`Edit`.
+Enter and confirm the password in the :guilabel:`SED Password` and
 :guilabel:`Confirm SED Password` fields. Disks that have a configured
-password will show bullets in their row of the :guilabel:`Password for SED`
-column of :menuselection:`Storage --> View Disks`. Conversely, the rows
-in that column will be empty for disks that do not support SED or which
-are unlocked using the global password.
+SED password show bullets in their row of the :guilabel:`SED Password`
+column of
+:menuselection:`Storage --> View Disks`.
+Conversely, the rows in that column will be empty for disks that do not
+support SED or are unlocked using the global password.
 
-Remember to take ownership of the devices:
+Now configure the SED to use the password. Go to the
+:menuselection:`Shell`
+and enter :samp:`sedhelper setup --disk {da1} {password}`, where *da1*
+is the SED to configure and *password* is the created password from
+:menuselection:`Storage --> View Disks --> Edit --> Password for SED`.
+
+**Repeat this process for each detected SED and any SED deployed to the
+%brand% system in the future.**
+
+.. danger:: It is important to remember SED passwords! Without them,
+   SEDs cannot be unlocked and their data is unavailable. While it is
+   possible to specify the PSID number on the label of the device with
+   :command:`sedutil-cli`, doing so **erases the contents** of the
+   device rather than unlock it. Always record SED passwords whenever
+   they are configured or modified and store them in a safe place!
+
+
+.. _Check SED Functionality:
+
+Check SED Functionality
+^^^^^^^^^^^^^^^^^^^^^^^
+
+When SED devices are detected during system boot, the middleware
+checks for configured global and device-specific passwords. Devices with
+individual passwords are unlocked with their password and any remaining
+devices that have no device-specific password are unlocked using the
+global password. No additional manual intervention is required, but
+:command:`sedhelper unlock` is available to manually unlock all SEDs.
+Unlocking SEDs allows a pool to contain a mix of SED and non-SED
+devices.
+
+To verify SED locking is working correctly, go to the
+:menuselection:`Shell`. Enter
+:samp:`sedutil-cli --listLockingRange 0 {password} dev/{da1}`, where
+*da1* is the SED and *password* is the global or individual password for
+that SED. The command returns :literal:`ReadLockEnabled: 1`,
+:literal:`WriteLockEnabled: 1`, and :literal:`LockOnReset: 1` when the
+SED has locking enabled. Example:
 
 .. code-block:: none
 
- sedhelper setup password
-
-This command ensures that all detected SED disks are properly setup using
-the specified password.
-
-.. note:: Rerun :command:`sedhelper setup password` every time a new SED
-   disk is placed in the system.
-
-This command is used to unlock all available SED disks:
-
-.. code-block:: none
-
- sedhelper unlock
+   root@truenas1:~ # sedutil-cli --listLockingRange 0 abcd1234 /dev/da9
+   Band[0]:
+       Name:            Global_Range
+       CommonName:      Locking
+       RangeStart:      0
+       RangeLength:     0
+       ReadLockEnabled: 1
+       WriteLockEnabled:1
+       ReadLocked:      0
+       WriteLocked:     0
+       LockOnReset:     1
 
 
 .. index:: Email

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -743,7 +743,7 @@ Three types of SED are supported:
 
 * TCG Enterprise standard for newer enterprise-grade SAS devices
 
-The %brand% middleware implements the security capabilities of
+%brand% implements the security capabilities of
 `camcontrol <https://www.freebsd.org/cgi/man.cgi?query=camcontrol>`__
 for legacy devices and
 `sedutil-cli <https://www.mankier.com/8/sedutil-cli>`__
@@ -753,15 +753,15 @@ the full capabilities of the device. %brand% provides the
 :command:`sedhelper` wrapper script to ease SED administration from the
 command line.
 
-By default, SED are not locked until the administrator takes ownership
-of them. This is done by explicitly configuring a global or per-device
-password in the %brand% |web-ui| and adding the password to the SEDs.
+By default, SEDs are not locked until the administrator takes ownership
+of them. Ownership is taken by explicitly configuring a global or
+per-device password in the %brand% |web-ui| and adding the password to
+the SEDs.
 
 A password-protected SED protects the data stored on the device
 when the device is physically removed from the %brand% system. This
-allows secure disposal of the device without having to first wipe its
-contents. If the device is instead removed to be repurposed on another
-system, it can only be unlocked if the password is known.
+allows secure disposal of the device without having to first wipe the
+contents. Repurposing a SED on another system requires the SED password.
 
 
 .. _Deploying SEDs:
@@ -769,9 +769,8 @@ system, it can only be unlocked if the password is known.
 Deploying SEDs
 ^^^^^^^^^^^^^^
 
-To determine which devices support SED and their device names, go to the
-:menuselection:`Shell`
-and enter :command:`sedutil-cli --scan`. In the results:
+Run :command:`sedutil-cli --scan` in the :ref:`Shell` to detect and list
+devices. The second column of the results identifies the drive type:
 
 * **no** indicates a non-SED device
 * **1** indicates a legacy TCG OPAL 1 device
@@ -795,10 +794,13 @@ Example:
 %brand% supports setting a global password for all detected SEDs or
 setting individual passwords for each SED. Using a global password for
 all SEDs is strongly recommended to simplify deployment and avoid
-physically maintaining separate passwords for each SED.
+maintaining separate passwords for each SED.
 
 
-**Setting a global password for SEDs**
+.. _Setting a global password for SEDs:
+
+Setting a global password for SEDs
+..................................
 
 Go to
 :menuselection:`System --> Advanced --> SED Password`
@@ -806,13 +808,12 @@ and enter the password. **Record this password and store it in a safe
 place!**
 
 Now the SEDs must be configured with this password. Go to the
-:menuselection:`Shell`
-and enter :samp:`sedhelper setup {password}`, where *password* is the
-global password entered in
+:ref:`Shell` and enter :samp:`sedhelper setup {password}`, where
+*password* is the global password entered in
 :menuselection:`System --> Advanced --> SED Password`.
 
 :command:`sedhelper` ensures that all detected SEDs are properly
-configured to use the provided password. Example:
+configured to use the provided password:
 
 .. code-block:: none
 
@@ -826,34 +827,39 @@ Rerun :samp:`sedhelper setup {password}` every time a new SED is placed
 in the system to apply the global password to the new SED.
 
 
-**Creating separate passwords for each SED**
+.. _Creating separate passwords for each SED:
+
+Creating separate passwords for each SED
+........................................
 
 Go to
 :menuselection:`Storage --> Volumes --> View Disks`.
 Click the confirmed SED, then :guilabel:`Edit`. Enter and confirm the
 password in the :guilabel:`Password for SED` and
-:guilabel:`Confirm SED Password` fields. Disks that have a configured
-SED password show bullets in their row of the
-:guilabel:`Password for SED` column of
-:menuselection:`Storage --> Volumes --> View Disks`.
-Conversely, the rows in that column will be empty for disks that do not
-support SED or are unlocked using the global password.
+:guilabel:`Confirm SED Password` fields.
 
-Now configure the SED to use the password. Go to the
-:menuselection:`Shell`
-and enter :samp:`sedhelper setup --disk {da1} {password}`, where *da1*
-is the SED to configure and *password* is the created password from
+The
+:menuselection:`Storage --> Volumes --> View Disks`.
+screen shows which disks have a configured SED password. The
+:guilabel:`SED Password` column shows a mark when the disk has a
+password. Disks that are not a SED or are unlocked using the global
+password are not marked in this column.
+
+The SED must be configured to use the new password. Go to the
+:ref:`Shell` and enter :samp:`sedhelper setup --disk {da1} {password}`,
+where *da1* is the SED to configure and *password* is the created
+password from
 :menuselection:`Storage --> Volumes --> View Disks --> Edit --> Password for SED`.
 
-**Repeat this process for each detected SED and any SED deployed to the
-%brand% system in the future.**
+This process must be repeated for each SED and any SEDs added to the
+system in the future.
 
-.. danger:: It is important to remember SED passwords! Without them,
-   SEDs cannot be unlocked and their data is unavailable. While it is
+.. danger:: Remember SED passwords! If the SED password is lost, SEDs
+   cannot be unlocked and their data is unavailable. While it is
    possible to specify the PSID number on the label of the device with
    :command:`sedutil-cli`, doing so **erases the contents** of the
    device rather than unlock it. Always record SED passwords whenever
-   they are configured or modified and store them in a safe place!
+   they are configured or modified and store them in a secure place!
 
 
 .. _Check SED Functionality:
@@ -861,22 +867,21 @@ is the SED to configure and *password* is the created password from
 Check SED Functionality
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-When SED devices are detected during system boot, the middleware
-checks for configured global and device-specific passwords. Devices with
-individual passwords are unlocked with their password and any remaining
-devices that have no device-specific password are unlocked using the
-global password. No additional manual intervention is required, but
-:command:`sedhelper unlock` is available to manually unlock all SEDs.
-Unlocking SEDs allows a pool to contain a mix of SED and non-SED
-devices.
+When SED devices are detected during system boot, %brand% checks for
+configured global and device-specific passwords.
 
-To verify SED locking is working correctly, go to the
-:menuselection:`Shell`. Enter
-:samp:`sedutil-cli --listLockingRange 0 {password} dev/{da1}`, where
-*da1* is the SED and *password* is the global or individual password for
-that SED. The command returns :literal:`ReadLockEnabled: 1`,
-:literal:`WriteLockEnabled: 1`, and :literal:`LockOnReset: 1` when the
-SED has locking enabled. Example:
+
+Unlocking SEDs allows a pool to contain a mix of SED and non-SED
+devices. Devices with individual passwords are unlocked with their
+password. Devices without a device-specific password are unlocked using
+the global password.
+
+To verify SED locking is working correctly, go to the :ref:`Shell`.
+Enter :samp:`sedutil-cli --listLockingRange 0 {password} dev/{da1}`,
+where *da1* is the SED and *password* is the global or individual
+password for that SED. The command returns :literal:`ReadLockEnabled: 1`,
+:literal:`WriteLockEnabled: 1`, and :literal:`LockOnReset: 1` for drives
+with locking enabled:
 
 .. code-block:: none
 

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -829,13 +829,13 @@ in the system to apply the global password to the new SED.
 **Creating separate passwords for each SED**
 
 Go to
-:menuselection:`Storage --> View Disks`.
-Click |ui-options| for the confirmed SED, then :guilabel:`Edit`.
-Enter and confirm the password in the :guilabel:`SED Password` and
+:menuselection:`Storage --> Volumes --> View Disks`.
+Click the confirmed SED, then :guilabel:`Edit`. Enter and confirm the
+password in the :guilabel:`Password for SED` and
 :guilabel:`Confirm SED Password` fields. Disks that have a configured
-SED password show bullets in their row of the :guilabel:`SED Password`
-column of
-:menuselection:`Storage --> View Disks`.
+SED password show bullets in their row of the
+:guilabel:`Password for SED` column of
+:menuselection:`Storage --> Volumes --> View Disks`.
 Conversely, the rows in that column will be empty for disks that do not
 support SED or are unlocked using the global password.
 
@@ -843,7 +843,7 @@ Now configure the SED to use the password. Go to the
 :menuselection:`Shell`
 and enter :samp:`sedhelper setup --disk {da1} {password}`, where *da1*
 is the SED to configure and *password* is the created password from
-:menuselection:`Storage --> View Disks --> Edit --> Password for SED`.
+:menuselection:`Storage --> Volumes --> View Disks --> Edit --> Password for SED`.
 
 **Repeat this process for each detected SED and any SED deployed to the
 %brand% system in the future.**


### PR DESCRIPTION
Cherry-pick previous commits to master and rework instructions to match legacy UI.
HTML build test: no issues.