### PR TITLE
NAS-100611: Add "All Disks" field to SMART Test Options table:

### DIFF
--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -114,6 +114,9 @@ These screen options have changed:
   and
   :menuselection:`System --> Certificates --> ADD`.
 
+* The :guilabel:`All Disks` checkbox has been added to
+  :menuselection:`Tasks --> S.M.A.R.T. Tests --> ADD`.
+
 * The :guilabel:`Use --fast-list` checkbox has been added to
   :menuselection:`Tasks --> Cloud Sync Tasks --> ADD`.
 

--- a/userguide/tasks.rst
+++ b/userguide/tasks.rst
@@ -659,7 +659,7 @@ summarizes the configurable options when creating a S.M.A.R.T. test.
    +======================+===================+==================================================================================================+
    | All Disks            | checkbox          | Set to monitor all disks.                                                                        |
    +----------------------+-------------------+--------------------------------------------------------------------------------------------------+
-   | Disks                | drop-down menu    | Select the disks to monitor.                                                                     |
+   | Disks                | drop-down menu    | Select the disks to monitor. Available when :guilabel:`All Disks` is unset.                      |
    |                      |                   |                                                                                                  |
    +----------------------+-------------------+--------------------------------------------------------------------------------------------------+
    | Type                 | drop-down menu    | Choose the test type. See                                                                        |

--- a/userguide/tasks.rst
+++ b/userguide/tasks.rst
@@ -653,26 +653,28 @@ summarizes the configurable options when creating a S.M.A.R.T. test.
 .. table:: S.M.A.R.T. Test Options
    :class: longtable
 
-   +-------------------+---------------------------+------------------------------------------------------------------------------------------------------------+
-   | Setting           | Value                     | Description                                                                                                |
-   |                   |                           |                                                                                                            |
-   +===================+===========================+============================================================================================================+
-   | Disks             | drop-down menu            | Select the disks to monitor.                                                                               |
-   |                   |                           |                                                                                                            |
-   +-------------------+---------------------------+------------------------------------------------------------------------------------------------------------+
-   | Type              | drop-down menu            | Choose the test type. See                                                                                  |
-   |                   |                           | `smartctl(8) <https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in>`__                  |
-   |                   |                           | for descriptions of each type. Some test types will degrade performance or take disks                      |
-   |                   |                           | offline. Avoid scheduling S.M.A.R.T. tests simultaneously with scrub or resilver operations.               |
-   |                   |                           |                                                                                                            |
-   +-------------------+---------------------------+------------------------------------------------------------------------------------------------------------+
-   | Short description | string                    | Optional. Enter a description of the S.M.A.R.T. test.                                                      |
-   |                   |                           |                                                                                                            |
-   +-------------------+---------------------------+------------------------------------------------------------------------------------------------------------+
-   | Schedule  the     | drop-down menu            | Choose how often to run the task. Choices are *Hourly*, *Daily*, *Weekly*, *Monthly*, or *Custom*. Select  |
-   | S.M.A.R.T. Test   |                           | *Custom* to open a visual scheduler for selecting minutes, hours, days, month, and days of week.           |
-   |                   |                           |                                                                                                            |
-   +-------------------+---------------------------+------------------------------------------------------------------------------------------------------------+
+   +----------------------+-------------------+--------------------------------------------------------------------------------------------------+
+   | Setting              | Value             | Description                                                                                      |
+   |                      |                   |                                                                                                  |
+   +======================+===================+==================================================================================================+
+   | All Disks            | checkbox          | Set to monitor all disks.                                                                        |
+   +----------------------+-------------------+--------------------------------------------------------------------------------------------------+
+   | Disks                | drop-down menu    | Select the disks to monitor.                                                                     |
+   |                      |                   |                                                                                                  |
+   +----------------------+-------------------+--------------------------------------------------------------------------------------------------+
+   | Type                 | drop-down menu    | Choose the test type. See                                                                        |
+   |                      |                   | `smartctl(8) <https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in>`__        |
+   |                      |                   | for descriptions of each type. Some test types will degrade performance or take disks            |
+   |                      |                   | offline. Avoid scheduling S.M.A.R.T. tests simultaneously with scrub or resilver operations.     |
+   |                      |                   |                                                                                                  |
+   +----------------------+-------------------+--------------------------------------------------------------------------------------------------+
+   | Short description    | string            | Optional. Enter a description of the S.M.A.R.T. test.                                            |
+   |                      |                   |                                                                                                  |
+   +----------------------+-------------------+--------------------------------------------------------------------------------------------------+
+   | Schedule the         | drop-down menu    | Choose how often to run the task. Choices are *Hourly*, *Daily*, *Weekly*, *Monthly*, or         |
+   | S.M.A.R.T. Test      |                   | *Custom*. Select *Custom* to open a visual scheduler for selecting minutes, hours, days, month,  |
+   |                      |                   | and days of week.                                                                                |
+   +----------------------+-------------------+--------------------------------------------------------------------------------------------------+
 
 
 An example configuration is to schedule a :guilabel:`Short Self-Test`


### PR DESCRIPTION
Add intro entry.
HTML build test: no issues.
Cherry-pick from #886 with image update dropped and one extra change:
Unify SMART Test Options table structure so cherry-picks between branches will be smoother.