### PR TITLE
NAS-101123: Indicate which CA/Cert create fields are hidden by type.

### DIFF
--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -2350,7 +2350,8 @@ If the certificate is signed by an external CA,
 such as Verisign, instead create a certificate signing request. To do
 so, set the :guilabel:`Type` to *Certificate Signing Request*. The
 options from :numref:`Figure %s <create_new_cert_fig>` display, but
-without the :guilabel:`Signing Certificate Authority` field.
+without the :guilabel:`Signing Certificate Authority` and
+:guilabel:`Lifetime` fields.
 
 Certificates that are imported, self-signed, or for which a
 certificate signing request is created are added as entries to


### PR DESCRIPTION
Text was already correct for CAs, one small change was needed for Certificate creation.
HTML build test: no issues.

Investigate and cherry-pick PR #969 