### PR TITLE
NAS-101219: Add "Administrators Group" field to "Global SMB Configuration Options" table

### DIFF
--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -172,6 +172,9 @@ These screen options have changed:
 * The :guilabel:`DOS Charset` field has been removed from
   :menuselection:`Services --> SMB --> Configure`.
 
+* The :guilabel:`Administrators Group` drop-down menu has been added to
+  :menuselection:`Services --> SMB`.
+
 
 .. _Path and Name Lengths:
 

--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -172,9 +172,6 @@ These screen options have changed:
 * The :guilabel:`DOS Charset` field has been removed from
   :menuselection:`Services --> SMB --> Configure`.
 
-* The :guilabel:`Administrators Group` drop-down menu has been added to
-  :menuselection:`Services --> SMB`.
-
 
 .. _Path and Name Lengths:
 

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1287,6 +1287,10 @@ This configuration screen is really a front-end to
    |                                  |                | to access the shared pool or dataset. If Guest Account user is deleted, resets to *nobody*.           |
    |                                  |                |                                                                                                       |
    +----------------------------------+----------------+-------------------------------------------------------------------------------------------------------+
+   | Administrators Group             | drop-down menu | Members of this group are local admins and automatically have privileges to take ownership of any     |
+   |                                  |                | file in an SMB share, reset permissions, and administer the SMB server through the Computer           |
+   |                                  |                | Management MMC snap-in.                                                                               |
+   +----------------------------------+----------------+-------------------------------------------------------------------------------------------------------+
    | File Mask                        | integer        | Overrides default file creation mask of *0666* which creates files with read and write access for     |
    |                                  |                | everybody.                                                                                            |
    |                                  |                |                                                                                                       |


### PR DESCRIPTION
cherry-pick from #984 with 11.2U4 specific intro entry removed.
Duplicate field description from 11.2-legacy branch.
Add intro entry
HTML build test: no issues.