### PR TITLE
NAS-101555: vmware text improvements master

### DIFF
--- a/userguide/install.rst
+++ b/userguide/install.rst
@@ -1093,9 +1093,10 @@ remove the virtual HPET hardware:
   change.
 
 
-If plugins or jails inside the %brand% VM are encountering network
-connectivity issues, edit the connected
-`VMware port group <https://pubs.vmware.com/vsphere-4-esx-vcenter/index.jsp?topic=/com.vmware.vsphere.server_configclassic.doc_40/esx_server_config/networking/c_port_groups.html>`__
-and
+Network connection errors for plugins or jails inside the %brand% VM can
+be caused by a misconfigured
 `virtual switch <https://pubs.vmware.com/vsphere-51/index.jsp?topic=%2Fcom.vmware.wssdk.pg.doc%2FPG_Networking.11.4.html>`__
-to allow MAC spoofing and enable promiscuous mode.
+or
+`VMware port group <https://pubs.vmware.com/vsphere-4-esx-vcenter/index.jsp?topic=/com.vmware.vsphere.server_configclassic.doc_40/esx_server_config/networking/c_port_groups.html>`__.
+Make sure MAC spoofing and promiscuous mode are enabled on the switch
+first, and then the port group the VM is using.

--- a/userguide/install.rst
+++ b/userguide/install.rst
@@ -1091,3 +1091,9 @@ remove the virtual HPET hardware:
   :file:`filename.vmx`. Open the file in a text editor and change
   :guilabel:`hpet0.present` from *true* to *false*, then save the
   change.
+
+
+If plugins or jails inside the %brand% VM are encountering network
+connectivity issues, edit the
+`VMware virtual switch <https://pubs.vmware.com/vsphere-51/index.jsp?topic=%2Fcom.vmware.wssdk.pg.doc%2FPG_Networking.11.4.html>`__
+to allow MAC spoofing and enable promiscuous mode.

--- a/userguide/install.rst
+++ b/userguide/install.rst
@@ -1094,6 +1094,8 @@ remove the virtual HPET hardware:
 
 
 If plugins or jails inside the %brand% VM are encountering network
-connectivity issues, edit the
-`VMware virtual switch <https://pubs.vmware.com/vsphere-51/index.jsp?topic=%2Fcom.vmware.wssdk.pg.doc%2FPG_Networking.11.4.html>`__
+connectivity issues, edit the connected
+`VMware port group <https://pubs.vmware.com/vsphere-4-esx-vcenter/index.jsp?topic=/com.vmware.vsphere.server_configclassic.doc_40/esx_server_config/networking/c_port_groups.html>`__
+and
+`virtual switch <https://pubs.vmware.com/vsphere-51/index.jsp?topic=%2Fcom.vmware.wssdk.pg.doc%2FPG_Networking.11.4.html>`__
 to allow MAC spoofing and enable promiscuous mode.


### PR DESCRIPTION
Add back vmware text mistakenly deleted in https://github.com/freenas/freenas-docs/commit/26039ceedeb4bc48362c10adc529f720230b97d1. This brings all branches back up into sync with this change.