### PR TITLE
NAS-100716: Remove TrueNAS note about alert if system dataset is not …

### DIFF
--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -986,14 +986,6 @@ system dataset. Whenever the location of the system dataset is
 changed, a pop-up warning indicates that the SMB service must be
 restarted, causing a temporary outage of any active SMB connections.
 
-#ifdef truenas
-.. note:: Storing the system dataset on the
-   :file:`freenas-boot` pool is recommended. For this reason,
-   a yellow system alert
-   will be generated when the system dataset is configured to
-   use another pool.
-#endif truenas
-
 To store the system log on the system dataset, enable the
 :guilabel:`Syslog` option.
 


### PR DESCRIPTION
…freenas-boot.

Verify that alert is not visible in TrueNAS guide alertevents.rst.
TrueNAS HTML build test: no issues.
Cherry-pick from #1046 