### PR TITLE
Port User Quota Administration section into sharing.rst to fix build warning

### DIFF
--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -1385,6 +1385,25 @@ username and password are provided. Logging out of Windows clears the
 cache. The authentication dialog reappears the next time the user
 connects to an authenticated share.
 
+.. _User Quota Administration:
+
+User Quota Administration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+File Explorer can manage quotas on SMB shares connected to an
+:ref:`Active Directory` server. Both the share and dataset being shared
+must be configured to allow this feature:
+
+* Create an authenticated share with :literal:`domain admins` as both
+  the user and group name in :guilabel:`Ownership`.
+
+* Edit the SMB share and add *ixnas* to the list of selected
+  :ref:`VFS Object <avail_vfs_modules_tab>`.
+
+* In Windows Explorer, connect to and map the share with a user account
+  which is a member of the :literal:`domain admins` group. The
+  :guilabel:`Quotas` tab becomes active.
+
 
 .. index:: Shadow Copies
 .. _Configuring Shadow Copies:


### PR DESCRIPTION
Fixes build warning for 11.2-legacy branch
Checked FreeNAS/TrueNAS 11.2U4.1 systems and confirmed with Andrew that text is relevant.
TrueNAS HTML build: no issues.