### PR TITLE
NAS-100087 , NAS-101289 : TrueNAS disk number mismatches

### DIFF
--- a/userguide/snippets/alertevents.rst
+++ b/userguide/snippets/alertevents.rst
@@ -118,7 +118,7 @@ Some of the conditions that trigger an alert include:
   as this condition could block future configuration changes from
   being applied to the standby node
 
-* one node of an HA pair has a different number of disks connected
+* Storage controllers do not have the same number of connected disks
 
 * the boot volume of the passive node is not HEALTHY
 

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -2839,7 +2839,7 @@ If both nodes reboot simultaneously, the GELI passphrase for an
 login screen.
 
 If there are a different number of disks connected to each node, an
-:ref:`Alert` is generated and the HA icon will switch to
+:ref:`Alert` is generated and the HA icon switches to
 :guilabel:`HA Unavailable`.
 
 #endif truenas

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -2764,7 +2764,7 @@ to the right of the :guilabel:`Alert` icon on the active node.
 
 When HA has been disabled by the system administrator, the status icon
 changes to :guilabel:`HA Disabled`. If the standby node is not
-available because it is powered off, still starting up, is disconnected
+available because it is powered off, still starting up, disconnected
 from the network, or if failover has not been configured, the status
 icon changes to :guilabel:`HA Unavailable`.
 

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -2764,9 +2764,9 @@ to the right of the :guilabel:`Alert` icon on the active node.
 
 When HA has been disabled by the system administrator, the status icon
 changes to :guilabel:`HA Disabled`. If the standby node is not
-available because it is powered off, still starting up, or is
-disconnected from the network, or if failover has not been configured,
-the status icon changes to :guilabel:`HA Unavailable`.
+available because it is powered off, still starting up, is disconnected
+from the network, or if failover has not been configured, the status
+icon changes to :guilabel:`HA Unavailable`.
 
 The icon is red when HA is starting up, disabled, or has encountered a
 problem. When HA is functioning normally, the icon turns green.
@@ -2838,5 +2838,8 @@ If both nodes reboot simultaneously, the GELI passphrase for an
 :ref:`encrypted <Encryption>` pool must be entered at the |web-ui|
 login screen.
 
+If there are a different number of disks connected to each node, an
+:ref:`Alert` is generated and the HA icon will switch to
+:guilabel:`HA Unavailable`.
 
 #endif truenas


### PR DESCRIPTION
- TrueNAS guide changes only
- Update alert message for disk mismatches
- Add text to Failover section about HA icon becoming unavailable for disk number mismatches
- TrueNAS HTML build test: no issues.