### PR TITLE
RM 9053: Add missing "Time Machine Quota" field to sharing.rst

### DIFF
--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -194,7 +194,7 @@ information given when the share was created.
    |                        |               |             | When multiple Macs share the same pool, low diskspace issues and intermittently failed backups can occur.    |
    |                        |               |             |                                                                                                              |
    +------------------------+---------------+-------------+--------------------------------------------------------------------------------------------------------------+
-   | Time Machine Quota,    | integer       |             | Appears when :guilabel:`Time Machine` is set. Enter a storage quota for each time machine backup on this     |
+   | Time Machine Quota,    | integer       |             | Appears when :guilabel:`Time Machine` is set. Enter a storage quota for each Time Machine backup on this     |
    | GiB                    |               |             | share. The share must be remounted for any changes to this value to take effect.                             |
    |                        |               |             |                                                                                                              |
    +------------------------+---------------+-------------+--------------------------------------------------------------------------------------------------------------+

--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -194,6 +194,10 @@ information given when the share was created.
    |                        |               |             | When multiple Macs share the same pool, low diskspace issues and intermittently failed backups can occur.    |
    |                        |               |             |                                                                                                              |
    +------------------------+---------------+-------------+--------------------------------------------------------------------------------------------------------------+
+   | Time Machine Quota,    | integer       |             | Appears when :guilabel:`Time Machine` is set. Enter a storage quota for each time machine backup on this     |
+   | GiB                    |               |             | share. The share must be remounted for any changes to this value to take effect.                             |
+   |                        |               |             |                                                                                                              |
+   +------------------------+---------------+-------------+--------------------------------------------------------------------------------------------------------------+
    | Zero Device Numbers    | checkbox      | ✓           | Enable when the device number is not constant across a reboot.                                               |
    |                        |               |             |                                                                                                              |
    +------------------------+---------------+-------------+--------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
- HTML build test: no issues.
- verified this field exists in new/legacy UI for 11.2