### PR TITLE
Nas100122 node term update master

### DIFF
--- a/userguide/conf.py
+++ b/userguide/conf.py
@@ -75,6 +75,14 @@ rst_prolog = u'''
 .. |bug-tracker-link| replace:: `<https://bugs.ixsystems.com>`__
 .. |copyright-year|   replace:: 2019
 .. |dockerhost|       replace:: Docker VM
+.. |Node|                 replace:: Storage Controller
+.. |Node-a|               replace:: Storage Controller 1
+.. |Node-b|               replace:: Storage Controller 2
+.. |Node-ab|              replace:: Storage Controller 1/2
+.. |node|                 replace:: storage controller
+.. |nodes|                replace:: storage controllers
+.. |node-a|               replace:: storage controller 1
+.. |node-b|               replace:: storage controller 2
 .. |os-device|        replace:: operating system device
 .. |os-devices|       replace:: operating system devices
 .. |OS-Device|        replace:: Operating System Device

--- a/userguide/conf.py
+++ b/userguide/conf.py
@@ -75,16 +75,16 @@ rst_prolog = u'''
 .. |bug-tracker-link| replace:: `<https://bugs.ixsystems.com>`__
 .. |copyright-year|   replace:: 2019
 .. |dockerhost|       replace:: Docker VM
-.. |Ctrlr-term|           replace:: Storage Controller
-.. |Ctrlrs-term|          replace:: Storage Controllers
-.. |Ctrlr-term-1|         replace:: Storage Controller 1
-.. |Ctrlr-term-2|         replace:: Storage Controller 2
-.. |Ctrlr-term-1-2|       replace:: Storage Controller 1/2
-.. |ctrlr-term|           replace:: storage controller
-.. |ctrlrs-term|          replace:: storage controllers
-.. |ctrlr-term-1|         replace:: storage controller 1
-.. |ctrlr-term-2|         replace:: storage controller 2
-.. |ctrlr-term-1-2|       replace:: storage controller 1/2
+.. |Ctrlr-term|       replace:: TrueNAS Controller
+.. |Ctrlrs-term|      replace:: TrueNAS Controllers
+.. |Ctrlr-term-1|     replace:: TrueNAS Controller 1
+.. |Ctrlr-term-2|     replace:: TrueNAS Controller 2
+.. |Ctrlr-term-1-2|   replace:: TrueNAS Controller 1/2
+.. |ctrlr-term|       replace:: TrueNAS controller
+.. |ctrlrs-term|      replace:: TrueNAS controllers
+.. |ctrlr-term-1|     replace:: TrueNAS controller 1
+.. |ctrlr-term-2|     replace:: TrueNAS controller 2
+.. |ctrlr-term-1-2|   replace:: TrueNAS controller 1/2
 .. |os-device|        replace:: operating system device
 .. |os-devices|       replace:: operating system devices
 .. |OS-Device|        replace:: Operating System Device

--- a/userguide/conf.py
+++ b/userguide/conf.py
@@ -76,6 +76,7 @@ rst_prolog = u'''
 .. |copyright-year|   replace:: 2019
 .. |dockerhost|       replace:: Docker VM
 .. |Node|                 replace:: Storage Controller
+.. |Nodes|                replace:: Storage Controllers
 .. |Node-a|               replace:: Storage Controller 1
 .. |Node-b|               replace:: Storage Controller 2
 .. |Node-ab|              replace:: Storage Controller 1/2

--- a/userguide/conf.py
+++ b/userguide/conf.py
@@ -75,15 +75,16 @@ rst_prolog = u'''
 .. |bug-tracker-link| replace:: `<https://bugs.ixsystems.com>`__
 .. |copyright-year|   replace:: 2019
 .. |dockerhost|       replace:: Docker VM
-.. |Node|                 replace:: Storage Controller
-.. |Nodes|                replace:: Storage Controllers
-.. |Node-a|               replace:: Storage Controller 1
-.. |Node-b|               replace:: Storage Controller 2
-.. |Node-ab|              replace:: Storage Controller 1/2
-.. |node|                 replace:: storage controller
-.. |nodes|                replace:: storage controllers
-.. |node-a|               replace:: storage controller 1
-.. |node-b|               replace:: storage controller 2
+.. |Ctrlr-term|           replace:: Storage Controller
+.. |Ctrlrs-term|          replace:: Storage Controllers
+.. |Ctrlr-term-1|         replace:: Storage Controller 1
+.. |Ctrlr-term-2|         replace:: Storage Controller 2
+.. |Ctrlr-term-1-2|       replace:: Storage Controller 1/2
+.. |ctrlr-term|           replace:: storage controller
+.. |ctrlrs-term|          replace:: storage controllers
+.. |ctrlr-term-1|         replace:: storage controller 1
+.. |ctrlr-term-2|         replace:: storage controller 2
+.. |ctrlr-term-1-2|       replace:: storage controller 1/2
 .. |os-device|        replace:: operating system device
 .. |os-devices|       replace:: operating system devices
 .. |OS-Device|        replace:: Operating System Device

--- a/userguide/directoryservice.rst
+++ b/userguide/directoryservice.rst
@@ -215,13 +215,13 @@ these settings by checking
    #ifdef truenas
    +--------------------------+---------------+-------------+--------------------------------------------------------------------------------------------------------------------------+
    | NetBIOS Name             | string        | ✓           | Limited to 15 characters. Automatically populated with the original hostname of the system. This **must**                |
-   | (This Node)              |               |             | be different from the *Workgroup* name                                                                                   |
+   | (This |Node|)            |               |             | be different from the *Workgroup* name                                                                                   |
    |                          |               |             |                                                                                                                          |
    +--------------------------+---------------+-------------+--------------------------------------------------------------------------------------------------------------------------+
-   | NetBIOS Name (Node A/B)  | string        | ✓           | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the standby node.                    |
-   |                          |               |             |                                                                                                                          |
+   | NetBIOS Name             | string        | ✓           | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the standby |node|.                  |
+   | (|Node-ab|)              |               |             |                                                                                                                          |
    +--------------------------+---------------+-------------+--------------------------------------------------------------------------------------------------------------------------+
-   | NetBIOS Alias            | string        | ✓           | Limited to 15 characters. When using :ref:`Failover`, this is the NetBIOS name that resolves to either node.             |
+   | NetBIOS Alias            | string        | ✓           | Limited to 15 characters. When using :ref:`Failover`, this is the NetBIOS name that resolves to either |node|.           |
    |                          |               |             |                                                                                                                          |
    #endif truenas
    +--------------------------+---------------+-------------+--------------------------------------------------------------------------------------------------------------------------+
@@ -608,15 +608,15 @@ Those new to LDAP terminology should read the
    #ifdef truenas
    +-------------------------+--------------+-------------+------------------------------------------------------------------------------------------------+
    | NetBIOS Name            | string       | ✓           | Limited to 15 characters. Automatically populated with the original hostname of the system.    |
-   | (This Node)             |              |             | This **must** be different from the *Workgroup* name.                                          |
+   | (This |Node|)           |              |             | This **must** be different from the *Workgroup* name.                                          |
    |                         |              |             |                                                                                                |
    +-------------------------+--------------+-------------+------------------------------------------------------------------------------------------------+
-   | NetBIOS Name (Node A/B) | string       | ✓           | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the        |
-   |                         |              |             | standby node.                                                                                  |
+   | NetBIOS Name            | string       | ✓           | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the        |
+   | (|Node-ab|)             |              |             | standby |node|.                                                                                |
    |                         |              |             |                                                                                                |
    +-------------------------+--------------+-------------+------------------------------------------------------------------------------------------------+
    | NetBIOS Alias           | string       | ✓           | Limited to 15 characters. When using :ref:`Failover`, this is the NetBIOS name that            |
-   |                         |              |             | resolves to either node.                                                                       |
+   |                         |              |             | resolves to either |node|.                                                                     |
    |                         |              |             |                                                                                                |
    #endif truenas
    +-------------------------+--------------+-------------+------------------------------------------------------------------------------------------------+

--- a/userguide/directoryservice.rst
+++ b/userguide/directoryservice.rst
@@ -215,13 +215,13 @@ these settings by checking
    #ifdef truenas
    +--------------------------+---------------+-------------+--------------------------------------------------------------------------------------------------------------------------+
    | NetBIOS Name             | string        | ✓           | Limited to 15 characters. Automatically populated with the original hostname of the system. This **must**                |
-   | (This |Node|)            |               |             | be different from the *Workgroup* name                                                                                   |
+   | (This |Ctrlr-term|)      |               |             | be different from the *Workgroup* name                                                                                   |
    |                          |               |             |                                                                                                                          |
    +--------------------------+---------------+-------------+--------------------------------------------------------------------------------------------------------------------------+
-   | NetBIOS Name             | string        | ✓           | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the standby |node|.                  |
-   | (|Node-ab|)              |               |             |                                                                                                                          |
+   | NetBIOS Name             | string        | ✓           | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the standby |ctrlr-term|.            |
+   | (|Ctrlr-term-1-2|)       |               |             |                                                                                                                          |
    +--------------------------+---------------+-------------+--------------------------------------------------------------------------------------------------------------------------+
-   | NetBIOS Alias            | string        | ✓           | Limited to 15 characters. When using :ref:`Failover`, this is the NetBIOS name that resolves to either |node|.           |
+   | NetBIOS Alias            | string        | ✓           | Limited to 15 characters. When using :ref:`Failover`, this is the NetBIOS name that resolves to either |ctrlr-term|.     |
    |                          |               |             |                                                                                                                          |
    #endif truenas
    +--------------------------+---------------+-------------+--------------------------------------------------------------------------------------------------------------------------+
@@ -608,15 +608,15 @@ Those new to LDAP terminology should read the
    #ifdef truenas
    +-------------------------+--------------+-------------+------------------------------------------------------------------------------------------------+
    | NetBIOS Name            | string       | ✓           | Limited to 15 characters. Automatically populated with the original hostname of the system.    |
-   | (This |Node|)           |              |             | This **must** be different from the *Workgroup* name.                                          |
+   | (This |Ctrlr-term|)     |              |             | This **must** be different from the *Workgroup* name.                                          |
    |                         |              |             |                                                                                                |
    +-------------------------+--------------+-------------+------------------------------------------------------------------------------------------------+
    | NetBIOS Name            | string       | ✓           | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the        |
-   | (|Node-ab|)             |              |             | standby |node|.                                                                                |
+   | (|Ctrlr-term-1-2|)      |              |             | standby |ctrlr-term|.                                                                          |
    |                         |              |             |                                                                                                |
    +-------------------------+--------------+-------------+------------------------------------------------------------------------------------------------+
    | NetBIOS Alias           | string       | ✓           | Limited to 15 characters. When using :ref:`Failover`, this is the NetBIOS name that            |
-   |                         |              |             | resolves to either |node|.                                                                     |
+   |                         |              |             | resolves to either |ctrlr-term|.                                                               |
    |                         |              |             |                                                                                                |
    #endif truenas
    +-------------------------+--------------+-------------+------------------------------------------------------------------------------------------------+

--- a/userguide/network.rst
+++ b/userguide/network.rst
@@ -87,11 +87,11 @@ but can be changed to meet requirements of the local network.
    +-------------------------+---------------+---------------------------------------------------------------------------------------------------+
 #endif freenas
 #ifdef truenas
-   | Hostname                | string        | Host name of first |node|.                                                                        |
-   | (This |Node|)           |               |                                                                                                   |
+   | Hostname                | string        | Host name of first |ctrlr-term|.                                                                  |
+   | (This |Ctrlr-term|)     |               |                                                                                                   |
    +-------------------------+---------------+---------------------------------------------------------------------------------------------------+
-   | Hostname                | string        | Host name of second |node|.                                                                       |
-   | (|Node-b|)              |               |                                                                                                   |
+   | Hostname                | string        | Host name of second |ctrlr-term|.                                                                 |
+   | (|Ctrlr-term-2|)        |               |                                                                                                   |
    +-------------------------+---------------+---------------------------------------------------------------------------------------------------+
    | Hostname (Virtual)      | string        | Virtual host name. When using a virtualhost, this is also used as the Kerberos principal name.    |
    |                         |               | Enter the fully qualified hostname plus the domain name. Upper and lower case alphanumeric,       |

--- a/userguide/network.rst
+++ b/userguide/network.rst
@@ -87,16 +87,15 @@ but can be changed to meet requirements of the local network.
    +-------------------------+---------------+---------------------------------------------------------------------------------------------------+
 #endif freenas
 #ifdef truenas
-   | Hostname (This Node)    | string        | Host name of first storage controller.                                                            |
-   |                         |               |                                                                                                   |
+   | Hostname                | string        | Host name of first |node|.                                                                        |
+   | (This |Node|)           |               |                                                                                                   |
    +-------------------------+---------------+---------------------------------------------------------------------------------------------------+
-   | Hostname (Node B)       | string        | Host name of second storage controller.                                                           |
-   |                         |               |                                                                                                   |
+   | Hostname                | string        | Host name of second |node|.                                                                       |
+   | (|Node-b|)              |               |                                                                                                   |
    +-------------------------+---------------+---------------------------------------------------------------------------------------------------+
    | Hostname (Virtual)      | string        | Virtual host name. When using a virtualhost, this is also used as the Kerberos principal name.    |
    |                         |               | Enter the fully qualified hostname plus the domain name. Upper and lower case alphanumeric,       |
    |                         |               | :literal:`.`, and :literal:`-` characters are allowed.                                            |
-   |                         |               |                                                                                                   |
    +-------------------------+---------------+---------------------------------------------------------------------------------------------------+
 #endif truenas
    | Domain                  | string        | System domain name.                                                                               |

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1332,14 +1332,14 @@ screen is really a front-end to
    #endif freenas
    #ifdef truenas
    | NetBIOS Name                | string            | Automatically populated with the original hostname of the system. Limited to 15 characters.          |
-   | (This |Node|)               |                   | It **must** be different from the *Workgroup* name.                                                  |
+   | (This |Ctrlr-term|)         |                   | It **must** be different from the *Workgroup* name.                                                  |
    |                             |                   |                                                                                                      |
    +-----------------------------+-------------------+------------------------------------------------------------------------------------------------------+
    | NetBIOS Name                | string            | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the              |
-   | (|Node-b|)                  |                   | standby |node|.                                                                                      |
+   | (|Ctrlr-term-2|)            |                   | standby |ctrlr-term|.                                                                                |
    +-----------------------------+-------------------+------------------------------------------------------------------------------------------------------+
    | NetBIOS Alias               | string            | Limited to 15 characters. When using :ref:`Failover`, this is the NetBIOS name that resolves         |
-   |                             |                   | to either |node|.                                                                                    |
+   |                             |                   | to either |ctrlr-term|.                                                                              |
    +-----------------------------+-------------------+------------------------------------------------------------------------------------------------------+
    #endif truenas
    | Workgroup                   | string            | Must match Windows workgroup name. This setting is ignored if the :ref:`Active Directory`            |

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1331,17 +1331,15 @@ screen is really a front-end to
    +-----------------------------+-------------------+------------------------------------------------------------------------------------------------------+
    #endif freenas
    #ifdef truenas
-   | NetBIOS Name (This Node)    | string            | Automatically populated with the original hostname of the system. Limited to 15 characters. It       |
-   |                             |                   | **must** be different from the *Workgroup* name.                                                     |
+   | NetBIOS Name                | string            | Automatically populated with the original hostname of the system. Limited to 15 characters.          |
+   | (This |Node|)               |                   | It **must** be different from the *Workgroup* name.                                                  |
    |                             |                   |                                                                                                      |
    +-----------------------------+-------------------+------------------------------------------------------------------------------------------------------+
-   | NetBIOS Name (Node B)       | string            | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the              |
-   |                             |                   | standby node                                                                                         |
-   |                             |                   |                                                                                                      |
+   | NetBIOS Name                | string            | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the              |
+   | (|Node-b|)                  |                   | standby |node|.                                                                                      |
    +-----------------------------+-------------------+------------------------------------------------------------------------------------------------------+
    | NetBIOS Alias               | string            | Limited to 15 characters. When using :ref:`Failover`, this is the NetBIOS name that resolves         |
-   |                             |                   | to either node.                                                                                      |
-   |                             |                   |                                                                                                      |
+   |                             |                   | to either |node|.                                                                                    |
    +-----------------------------+-------------------+------------------------------------------------------------------------------------------------------+
    #endif truenas
    | Workgroup                   | string            | Must match Windows workgroup name. This setting is ignored if the :ref:`Active Directory`            |

--- a/userguide/snippets/alertevents.rst
+++ b/userguide/snippets/alertevents.rst
@@ -40,7 +40,7 @@ or from the Web Shell
 by running :command:`alertcli.py`.
 #ifdef truenas
 Alert messages indicate which :ref:`High Availability (HA) <Failover>`
-|node| generated the alert.
+|ctrlr-term| generated the alert.
 #endif truenas
 
 Some of the conditions that trigger an alert include:
@@ -116,20 +116,20 @@ Some of the conditions that trigger an alert include:
 
 * HA is configured but the connection is not established
 
-* one |node| of an HA pair gets stuck applying its configuration journal
-  as this condition could block future configuration changes from
-  being applied to the standby |node|
+* one |ctrlr-term| of an HA pair gets stuck applying its configuration
+  journal as this condition could block future configuration changes
+  from being applied to the standby |ctrlr-term|
 
-* |Nodes| do not have the same number of connected disks
+* |Ctrlrs-term| do not have the same number of connected disks
 
-* the boot volume of the passive |node| is not HEALTHY
+* the boot volume of the passive |ctrlr-term| is not HEALTHY
 
 * 30 days before the license expires, and when the license expires
 
 * the usage of a HA link goes above 10MB/s
 
-* an IPMI query to a standby |node| fails, indicating the standby |node|
-  is down
+* an IPMI query to a standby |ctrlr-term| fails, indicating the standby
+  |ctrlr-term| is down
 
 * :ref:`Proactive Support` is enabled but any of the configuration
   fields are empty
@@ -141,7 +141,7 @@ Some of the conditions that trigger an alert include:
 * if a USB storage device has been attached which could prevent
   booting or failover
 
-* when the passive |node| cannot be contacted
+* when the passive |ctrlr-term| cannot be contacted
 
 * when it is 180, 90, 30, or 14 days before support contract
   expiration

--- a/userguide/snippets/alertevents.rst
+++ b/userguide/snippets/alertevents.rst
@@ -40,7 +40,7 @@ or from the Web Shell
 by running :command:`alertcli.py`.
 #ifdef truenas
 Alert messages indicate which :ref:`High Availability (HA) <Failover>`
-node generated the alert.
+|node| generated the alert.
 #endif truenas
 
 Some of the conditions that trigger an alert include:
@@ -116,19 +116,19 @@ Some of the conditions that trigger an alert include:
 
 * HA is configured but the connection is not established
 
-* one node of an HA pair gets stuck applying its configuration journal
+* one |node| of an HA pair gets stuck applying its configuration journal
   as this condition could block future configuration changes from
-  being applied to the standby node
+  being applied to the standby |node|
 
 * Storage controllers do not have the same number of connected disks
 
-* the boot volume of the passive node is not HEALTHY
+* the boot volume of the passive |node| is not HEALTHY
 
 * 30 days before the license expires, and when the license expires
 
 * the usage of a HA link goes above 10MB/s
 
-* an IPMI query to a standby node fails, indicating the standby node
+* an IPMI query to a standby |node| fails, indicating the standby |node|
   is down
 
 * :ref:`Proactive Support` is enabled but any of the configuration
@@ -141,7 +141,7 @@ Some of the conditions that trigger an alert include:
 * if a USB storage device has been attached which could prevent
   booting or failover
 
-* when the passive node cannot be contacted
+* when the passive |node| cannot be contacted
 
 * when it is 180, 90, 30, or 14 days before support contract
   expiration

--- a/userguide/snippets/alertevents.rst
+++ b/userguide/snippets/alertevents.rst
@@ -120,7 +120,7 @@ Some of the conditions that trigger an alert include:
   journal as this condition could block future configuration changes
   from being applied to the standby |ctrlr-term|
 
-* |Ctrlrs-term| do not have the same number of connected disks
+* |ctrlrs-term| do not have the same number of connected disks
 
 * the boot volume of the passive |ctrlr-term| is not HEALTHY
 

--- a/userguide/snippets/alertevents.rst
+++ b/userguide/snippets/alertevents.rst
@@ -120,7 +120,7 @@ Some of the conditions that trigger an alert include:
   as this condition could block future configuration changes from
   being applied to the standby |node|
 
-* Storage controllers do not have the same number of connected disks
+* |Nodes| do not have the same number of connected disks
 
 * the boot volume of the passive |node| is not HEALTHY
 

--- a/userguide/snippets/console_menu.rst
+++ b/userguide/snippets/console_menu.rst
@@ -24,8 +24,8 @@ The menu provides these options:
 wizard to set up the system's network interfaces.
 #ifdef truenas
 If the system has been licensed for High Availability (HA), the wizard
-prompts for IP addresses for both :guilabel:`(This Node)` and
-:guilabel:`(Node B)`.
+prompts for IP addresses for both :guilabel:`(This |Node|)` and
+:guilabel:`(|Node-b|)`.
 
 The wizard also prompts marking an interface as critical for failover.
 This allows logging in to the |web-ui| available at the virtual IP

--- a/userguide/snippets/console_menu.rst
+++ b/userguide/snippets/console_menu.rst
@@ -24,8 +24,8 @@ The menu provides these options:
 wizard to set up the system's network interfaces.
 #ifdef truenas
 If the system has been licensed for High Availability (HA), the wizard
-prompts for IP addresses for both :guilabel:`(This |Node|)` and
-:guilabel:`(|Node-b|)`.
+prompts for IP addresses for both :guilabel:`(This |Ctrlr-term|)` and
+:guilabel:`(|Ctrlr-term-2|)`.
 
 The wizard also prompts marking an interface as critical for failover.
 This allows logging in to the |web-ui| available at the virtual IP

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -26,10 +26,10 @@ these options:
 
 #ifdef truenas
 .. note:: When using an HA (High Availability) %brand% system,
-   connecting to the graphical interface on the passive node only
-   shows a screen indicating that it is the passive node. All of the
+   connecting to the |web-ui| on the passive |node| only
+   shows a screen indicating that it is the passive |node|. All of the
    options discussed in this chapter can only be configured on the
-   active node.
+   active |node|.
 #endif truenas
 
 

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -26,10 +26,10 @@ these options:
 
 #ifdef truenas
 .. note:: When using an HA (High Availability) %brand% system,
-   connecting to the |web-ui| on the passive |node| only
-   shows a screen indicating that it is the passive |node|. All of the
-   options discussed in this chapter can only be configured on the
-   active |node|.
+   connecting to the |web-ui| on the passive |ctrlr-term| only
+   shows a screen indicating that it is the passive |ctrlr-term|. All of
+   the options discussed in this chapter can only be configured on the
+   active |ctrlr-term|.
 #endif truenas
 
 

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -1911,20 +1911,20 @@ Updating an HA System
 ~~~~~~~~~~~~~~~~~~~~~
 
 If the %brand% array has been configured for High Availability
-(HA), the update process must be started on the active node. Once
-the update is complete, the standby node will automatically reboot.
+(HA), the update process must be started on the active |node|. Once
+the update is complete, the standby |node| will automatically reboot.
 Wait for it to come back up by monitoring the remote console or the
-graphical administrative interface of the standby node.
+|web-ui| of the standby |node|.
 
-After the standby node has finished booting, it is important to
-perform a failover by rebooting the current active node. This action
-tells the standby node to import the current configuration and restart
+After the standby |node| has finished booting, it is important to
+perform a failover by rebooting the current active |node|. This action
+tells the standby |node| to import the current configuration and restart
 services.
 
-Once the previously active node comes back up as a standby node, use
+Once the previously active |node| comes back up as a standby |node|, use
 :menuselection:`System --> Update`
-to apply the update on the current active node, which was
-previously the passive node. Once complete, the now standby node
+to apply the update on the current active |node| (which was
+previously the passive |node|). Once complete, the now standby |node|
 will reboot a second time.
 
 
@@ -2178,7 +2178,7 @@ certificate.
 #ifdef truenas
 On %brand% :ref:`High Availability (HA) <Failover>` systems, the
 imported certificate must include the IP addresses or DNS hostnames of
-both nodes and the CARP virtual IP address. These IP addresses or DNS
+both |nodes| and the CARP virtual IP address. These IP addresses or DNS
 hostnames can be placed in the :guilabel:`Subject Alternative Name`
 (SAN) x509 extension field of the certificate being imported.
 #endif truenas
@@ -2685,14 +2685,14 @@ in the chassis. After the license is activated, the
 :guilabel:`Failover` tab is added to :guilabel:`System` and some
 fields are modified in :guilabel:`Network` so that the peer IP
 address, peer hostname, and virtual IP can be configured. An extra
-:guilabel:`IPMI (Node A/B)` tab will also be added so that
+:guilabel:`IPMI (|Node-ab|)` tab will also be added so that
 :ref:`IPMI` can be configured for the other unit.
 
 
-.. note:: The modified fields refer to this node as *This Node* and
-   the other node as either *A* or *B*. The node value is hard-coded
+.. note:: The modified fields refer to this |node| as *This |Node|* and
+   the other |node| as either *1* or *2*. The |node| value is hard-coded
    into each unit and the value that appears is automatically
-   generated. For example, on node *A*, the fields refer to node *B*,
+   generated. For example, on |node| *1*, the fields refer to |node| *2*,
    and vice versa.
 
 
@@ -2700,11 +2700,11 @@ To configure HA networking, go to
 :menuselection:`Network --> Global Configuration`.
 The :guilabel:`Hostname` field is replaced by three fields:
 
-* **Hostname (Node A/B):** enter the hostname to use for the other
-  node.
+* **Hostname (|Node-ab|):** enter the hostname to use for the other
+  |node|.
 
-* **Hostname (This Node):** enter the hostname to use for this
-  node.
+* **Hostname (This |Node|):** enter the hostname to use for this
+  |node|.
 
 * **Hostname (Virtual):** Enter the fully qualified hostname plus the
   domain name. When using a virtualhost, this is also used as the
@@ -2715,10 +2715,10 @@ Next, go to
 The HA license adds several fields to the usual :ref:`Interfaces`
 screen:
 
-* **IPv4 Address (Node A/B):** if the other node will use a static
+* **IPv4 Address (|Node-ab|):** if the other |node| will use a static
   IP address, rather than DHCP, set it here.
 
-* **IPv4 Address (This Node):** if this node will use a static IP
+* **IPv4 Address (This |Node|):** if this |node| will use a static IP
   address, rather than DHCP, set it here.
 
 * **Virtual IP:** enter the IP address to use for administrative
@@ -2749,22 +2749,22 @@ screen:
 After the network configuration is complete, log out and log back in,
 this time using the :guilabel:`Virtual IP` address. Volumes and shares
 can now be configured as usual and configuration automatically
-synchronizes between the active and the standby node.
+synchronizes between the active and the standby |node|.
 
-The passive or standby node indicates the virtual IP address that is
-used for configuration management. The standby node also has a red
+The passive or standby |node| indicates the virtual IP address that is
+used for configuration management. The standby |node| also has a red
 :guilabel:`Standby` icon and no longer accepts logins as all
-configuration changes must occur on the active node.
+configuration changes must occur on the active |node|.
 
 
 .. note:: After the :guilabel:`Virtual IP` address is configured, all
    subsequent logins should use that address.
 
-After HA has been configured, an :guilabel:`HA Enabled` icon appears
-to the right of the :guilabel:`Alert` icon on the active node.
+After HA is configured, an :guilabel:`HA Enabled` icon appears
+to the right of the :guilabel:`Alert` icon on the active |node|.
 
-When HA has been disabled by the system administrator, the status icon
-changes to :guilabel:`HA Disabled`. If the standby node is not
+When HA is disabled by the system administrator, the status icon
+changes to :guilabel:`HA Disabled`. If the standby |node| is not
 available because it is powered off, still starting up, disconnected
 from the network, or if failover has not been configured, the status
 icon changes to :guilabel:`HA Unavailable`.
@@ -2796,37 +2796,37 @@ and described in
 .. table:: Failover Options
    :class: longtable
 
-   +--------------+-------------+------------------------------------------------------------------------------------------------------------------------------------------+
-   | Setting      | Value       | Description                                                                                                                              |
-   |              |             |                                                                                                                                          |
-   +==============+=============+==========================================================================================================================================+
-   | Disabled     | checkbox    | Set to disable failover.                                                                                                                 |
-   |              |             | The :guilabel:`HA Enabled` icon changes to :guilabel:`HA Disabled` and activates the :guilabel:`Master` field.                           |
-   |              |             | An error message is generated if the standby node is not responding or failover is not configured.                                       |
-   |              |             |                                                                                                                                          |
-   +--------------+-------------+------------------------------------------------------------------------------------------------------------------------------------------+
-   | Master       | checkbox    | Grayed out unless :guilabel:`Disabled` is selected.                                                                                      |
-   |              |             | In that case, this option is automatically enabled on the master system,                                                                 |
-   |              |             | allowing the master to automatically take over when the :guilabel:`Disabled` option is deselected.                                       |
-   +--------------+-------------+------------------------------------------------------------------------------------------------------------------------------------------+
-   | Timeout      | integer     | Specify, in seconds, how quickly failover occurs after a network failure.                                                                |
-   |              |             | The default of *0* indicates that failover either occurs immediately or, if the system is using a link aggregation, after 2 seconds.     |
-   |              |             |                                                                                                                                          |
-   +--------------+-------------+------------------------------------------------------------------------------------------------------------------------------------------+
-   | Sync to      | button      | Open a dialog window to force the %brand% configuration to sync from the active node to the standby node.                                |
-   | Peer         |             | After the sync, the standby node must be rebooted (enabled by default) to load the new configuration.                                    |
-   |              |             | *Do not use this unless requested by an iXsystems support engineer, the HA daemon normally handles configuration sync automatically*.    |
-   |              |             |                                                                                                                                          |
-   +--------------+-------------+------------------------------------------------------------------------------------------------------------------------------------------+
-   | Sync From    | button      | Open a dialog window to force the %brand% configuration to sync from the standby node to the active node.                                |
-   | Peer         |             | *Do not use this unless requested by an iXsystems support engineer, the HA daemon normally handles configuration sync automatically*.    |
-   |              |             |                                                                                                                                          |
-   +--------------+-------------+------------------------------------------------------------------------------------------------------------------------------------------+
+   +----------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Setting        | Value          | Description                                                                                                                                        |
+   |                |                |                                                                                                                                                    |
+   +================+================+====================================================================================================================================================+
+   | Disabled       | checkbox       | Set to disable failover. The :guilabel:`HA Enabled` icon changes to :guilabel:`HA Disabled` and                                                    |
+   |                |                | activates the :guilabel:`Master` field. An error message is generated if the standby |node| is not responding or failover is not                   |
+   |                |                | configured.                                                                                                                                        |
+   |                |                |                                                                                                                                                    |
+   +----------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Master         | checkbox       | Grayed out unless :guilabel:`Disabled` is selected. In that case, this option is automatically enabled on the master system, allowing the          |
+   |                |                | master to automatically take over when the :guilabel:`Disabled` option is deselected.                                                              |
+   |                |                |                                                                                                                                                    |
+   +----------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Timeout        | integer        | Specify, in seconds, how quickly failover occurs after a network failure. The default of *0* indicates that failover either occurs immediately or, |
+   |                |                | if the system is using a link aggregation, after 2 seconds.                                                                                        |
+   |                |                |                                                                                                                                                    |
+   +----------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Sync to Peer   | button         | Open a dialog window to force the %brand% configuration to sync from the active                                                                    |
+   |                |                | |node| to the standby |node|. After the sync, the standby |node| must be rebooted (enabled by default)                                             |
+   |                |                | to load the new configuration. *Do not use this unless requested by an iXsystems support engineer, the HA daemon normally                          |
+   |                |                | handles configuration sync automatically.*                                                                                                         |
+   +----------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
+   | Sync From Peer | button         | Open a dialog window to force the %brand% configuration to sync from the standby                                                                   |
+   |                |                | |node| to the active |node|. *Do not use this unless requested by an iXsystems support engineer, the HA daemon normally                            |
+   |                |                | handles configuration sync automatically.*                                                                                                         |
+   +----------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
 **Notes about High Availability and failovers:**
 
-Booting an HA pair with failover disabled causes both nodes to come up
+Booting an HA pair with failover disabled causes both |nodes| to come up
 in standby mode. The |web-ui| shows an additional
 :guilabel:`Force Takeover` button which can be used to force that node
 to take control.
@@ -2835,11 +2835,11 @@ The %brand% version of the :command:`ifconfig` command adds two
 additional fields to the output to help with failover troubleshooting:
 :samp:`CriticalGroup{n}` and :samp:`Interlink`.
 
-If both nodes reboot simultaneously, the GELI passphrase for an
-:ref:`encrypted <Encryption>` pool must be entered at the |web-ui|
-login screen.
+If both |nodes| reboot simultaneously, the GELI passphrase for an
+:ref:`encrypted <Managing Encrypted Pools>` pool must be entered at the
+|web-ui| login screen.
 
-If there are a different number of disks connected to each node, an
+If there are a different number of disks connected to each |node|, an
 :ref:`Alert` is generated and the HA icon switches to
 :guilabel:`HA Unavailable`.
 

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -2650,15 +2650,15 @@ a :guilabel:`Failover` tab is added to :guilabel:`System`.
 
 %brand% uses an active/standby configuration of dual storage
 controllers for HA. Dual-ported disk drives are connected to both
-storage controllers simultaneously. One storage controller is active,
-the other standby. The active controller sends periodic announcements
-to the network. If a fault occurs and the active controller stops
-sending the announcements, the standby controller detects this and
-initiates a failover. Storage and cache devices are imported on the
-standby controller, then I/O operations switch over to it. The standby
-controller then becomes the active controller. This failover operation
-can happen in seconds rather than the minutes of other configurations,
-significantly reducing the chance of a client timeout.
+|nodes| simultaneously. One |node| is active, the other standby. The
+active |node| sends periodic announcements to the network. If a fault
+occurs and the active |node| stops sending the announcements, the
+standby |node| detects this and initiates a failover. Storage and cache
+devices are imported on the standby |node|, then I/O operations switch
+over to it. The standby |node| then becomes the active |node|. This
+failover operation can happen in seconds rather than the minutes of
+other configurations, significantly reducing the chance of a client
+timeout.
 
 The Common Address Redundancy Protocol
 (`CARP <http://www.openbsd.org/faq/pf/carp.html>`__)

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -1911,21 +1911,22 @@ Updating an HA System
 ~~~~~~~~~~~~~~~~~~~~~
 
 If the %brand% array has been configured for High Availability
-(HA), the update process must be started on the active |node|. Once
-the update is complete, the standby |node| will automatically reboot.
-Wait for it to come back up by monitoring the remote console or the
-|web-ui| of the standby |node|.
+(HA), the update process must be started on the active |ctrlr-term|.
+Once the update is complete, the standby |ctrlr-term| will automatically
+reboot. Wait for it to come back up by monitoring the remote console or
+the |web-ui| of the standby |ctrlr-term|.
 
-After the standby |node| has finished booting, it is important to
-perform a failover by rebooting the current active |node|. This action
-tells the standby |node| to import the current configuration and restart
-services.
+After the standby |ctrlr-term| has finished booting, it is important to
+perform a failover by rebooting the current active |ctrlr-term|. This
+action tells the standby |ctrlr-term| to import the current
+configuration and restart services.
 
-Once the previously active |node| comes back up as a standby |node|, use
+Once the previously active |ctrlr-term| comes back up as a standby
+|ctrlr-term|, use
 :menuselection:`System --> Update`
-to apply the update on the current active |node| (which was
-previously the passive |node|). Once complete, the now standby |node|
-will reboot a second time.
+to apply the update on the current active |ctrlr-term| (which was
+previously the passive |ctrlr-term|). Once complete, the now standby
+|ctrlr-term| will reboot a second time.
 
 
 .. _If Something Goes Wrong:
@@ -2178,9 +2179,10 @@ certificate.
 #ifdef truenas
 On %brand% :ref:`High Availability (HA) <Failover>` systems, the
 imported certificate must include the IP addresses or DNS hostnames of
-both |nodes| and the CARP virtual IP address. These IP addresses or DNS
-hostnames can be placed in the :guilabel:`Subject Alternative Name`
-(SAN) x509 extension field of the certificate being imported.
+both |ctrlrs-term| and the CARP virtual IP address. These IP addresses
+or DNS hostnames can be placed in the
+:guilabel:`Subject Alternative Name` (SAN) x509 extension field of the
+certificate being imported.
 #endif truenas
 
 
@@ -2650,15 +2652,15 @@ a :guilabel:`Failover` tab is added to :guilabel:`System`.
 
 %brand% uses an active/standby configuration of dual storage
 controllers for HA. Dual-ported disk drives are connected to both
-|nodes| simultaneously. One |node| is active, the other standby. The
-active |node| sends periodic announcements to the network. If a fault
-occurs and the active |node| stops sending the announcements, the
-standby |node| detects this and initiates a failover. Storage and cache
-devices are imported on the standby |node|, then I/O operations switch
-over to it. The standby |node| then becomes the active |node|. This
-failover operation can happen in seconds rather than the minutes of
-other configurations, significantly reducing the chance of a client
-timeout.
+|ctrlrs-term| simultaneously. One |ctrlr-term| is active, the other
+standby. The active |ctrlr-term| sends periodic announcements to the
+network. If a fault occurs and the active |ctrlr-term| stops sending the
+announcements, the standby |ctrlr-term| detects this and initiates a
+failover. Storage and cache devices are imported on the standby
+|ctrlr-term|, then I/O operations switch over to it. The standby
+|ctrlr-term| then becomes the active |ctrlr-term|. This failover
+operation can happen in seconds rather than the minutes of other
+configurations, significantly reducing the chance of a client timeout.
 
 The Common Address Redundancy Protocol
 (`CARP <http://www.openbsd.org/faq/pf/carp.html>`__)
@@ -2685,26 +2687,26 @@ in the chassis. After the license is activated, the
 :guilabel:`Failover` tab is added to :guilabel:`System` and some
 fields are modified in :guilabel:`Network` so that the peer IP
 address, peer hostname, and virtual IP can be configured. An extra
-:guilabel:`IPMI (|Node-ab|)` tab will also be added so that
+:guilabel:`IPMI (|Ctrlr-term-1-2|)` tab will also be added so that
 :ref:`IPMI` can be configured for the other unit.
 
 
-.. note:: The modified fields refer to this |node| as *This |Node|* and
-   the other |node| as either *1* or *2*. The |node| value is hard-coded
-   into each unit and the value that appears is automatically
-   generated. For example, on |node| *1*, the fields refer to |node| *2*,
-   and vice versa.
+.. note:: The modified fields refer to this |ctrlr-term| as
+   *This |Ctrlr-term|* and the other |ctrlr-term| as either *1* or *2*.
+   The |ctrlr-term| value is hard-coded into each unit and the value
+   that appears is automatically generated. For example, on |ctrlr-term|
+   *1*, the fields refer to |ctrlr-term| *2*, and vice versa.
 
 
 To configure HA networking, go to
 :menuselection:`Network --> Global Configuration`.
 The :guilabel:`Hostname` field is replaced by three fields:
 
-* **Hostname (|Node-ab|):** enter the hostname to use for the other
-  |node|.
+* **Hostname (|Ctrlr-term-1-2|):** enter the hostname to use for the
+  other |ctrlr-term|.
 
-* **Hostname (This |Node|):** enter the hostname to use for this
-  |node|.
+* **Hostname (This |Ctrlr-term|):** enter the hostname to use for this
+  |ctrlr-term|.
 
 * **Hostname (Virtual):** Enter the fully qualified hostname plus the
   domain name. When using a virtualhost, this is also used as the
@@ -2715,11 +2717,11 @@ Next, go to
 The HA license adds several fields to the usual :ref:`Interfaces`
 screen:
 
-* **IPv4 Address (|Node-ab|):** if the other |node| will use a static
-  IP address, rather than DHCP, set it here.
+* **IPv4 Address (|Ctrlr-term-1-2|):** if the other |ctrlr-term| will
+  use a static IP address, rather than DHCP, set it here.
 
-* **IPv4 Address (This |Node|):** if this |node| will use a static IP
-  address, rather than DHCP, set it here.
+* **IPv4 Address (This |Ctrlr-term|):** if this |ctrlr-term| will use a
+  static IP address, rather than DHCP, set it here.
 
 * **Virtual IP:** enter the IP address to use for administrative
   access to the array.
@@ -2749,22 +2751,22 @@ screen:
 After the network configuration is complete, log out and log back in,
 this time using the :guilabel:`Virtual IP` address. Volumes and shares
 can now be configured as usual and configuration automatically
-synchronizes between the active and the standby |node|.
+synchronizes between the active and the standby |ctrlr-term|.
 
-The passive or standby |node| indicates the virtual IP address that is
-used for configuration management. The standby |node| also has a red
-:guilabel:`Standby` icon and no longer accepts logins as all
-configuration changes must occur on the active |node|.
+The passive or standby |ctrlr-term| indicates the virtual IP address
+that is used for configuration management. The standby |ctrlr-term| also
+has a red :guilabel:`Standby` icon and no longer accepts logins as all
+configuration changes must occur on the active |ctrlr-term|.
 
 
 .. note:: After the :guilabel:`Virtual IP` address is configured, all
    subsequent logins should use that address.
 
 After HA is configured, an :guilabel:`HA Enabled` icon appears
-to the right of the :guilabel:`Alert` icon on the active |node|.
+to the right of the :guilabel:`Alert` icon on the active |ctrlr-term|.
 
 When HA is disabled by the system administrator, the status icon
-changes to :guilabel:`HA Disabled`. If the standby |node| is not
+changes to :guilabel:`HA Disabled`. If the standby |ctrlr-term| is not
 available because it is powered off, still starting up, disconnected
 from the network, or if failover has not been configured, the status
 icon changes to :guilabel:`HA Unavailable`.
@@ -2801,7 +2803,7 @@ and described in
    |                |                |                                                                                                                                                    |
    +================+================+====================================================================================================================================================+
    | Disabled       | checkbox       | Set to disable failover. The :guilabel:`HA Enabled` icon changes to :guilabel:`HA Disabled` and                                                    |
-   |                |                | activates the :guilabel:`Master` field. An error message is generated if the standby |node| is not responding or failover is not                   |
+   |                |                | activates the :guilabel:`Master` field. An error message is generated if the standby |ctrlr-term| is not responding or failover is not             |
    |                |                | configured.                                                                                                                                        |
    |                |                |                                                                                                                                                    |
    +----------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -2814,20 +2816,20 @@ and described in
    |                |                |                                                                                                                                                    |
    +----------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
    | Sync to Peer   | button         | Open a dialog window to force the %brand% configuration to sync from the active                                                                    |
-   |                |                | |node| to the standby |node|. After the sync, the standby |node| must be rebooted (enabled by default)                                             |
+   |                |                | |ctrlr-term| to the standby |ctrlr-term|. After the sync, the standby |ctrlr-term| must be rebooted (enabled by default)                           |
    |                |                | to load the new configuration. *Do not use this unless requested by an iXsystems support engineer, the HA daemon normally                          |
    |                |                | handles configuration sync automatically.*                                                                                                         |
    +----------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
    | Sync From Peer | button         | Open a dialog window to force the %brand% configuration to sync from the standby                                                                   |
-   |                |                | |node| to the active |node|. *Do not use this unless requested by an iXsystems support engineer, the HA daemon normally                            |
+   |                |                | |ctrlr-term| to the active |ctrlr-term|. *Do not use this unless requested by an iXsystems support engineer, the HA daemon normally                |
    |                |                | handles configuration sync automatically.*                                                                                                         |
    +----------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
 **Notes about High Availability and failovers:**
 
-Booting an HA pair with failover disabled causes both |nodes| to come up
-in standby mode. The |web-ui| shows an additional
+Booting an HA pair with failover disabled causes both |ctrlrs-term| to
+come up in standby mode. The |web-ui| shows an additional
 :guilabel:`Force Takeover` button which can be used to force that node
 to take control.
 
@@ -2835,12 +2837,12 @@ The %brand% version of the :command:`ifconfig` command adds two
 additional fields to the output to help with failover troubleshooting:
 :samp:`CriticalGroup{n}` and :samp:`Interlink`.
 
-If both |nodes| reboot simultaneously, the GELI passphrase for an
+If both |ctrlrs-term| reboot simultaneously, the GELI passphrase for an
 :ref:`encrypted <Managing Encrypted Pools>` pool must be entered at the
 |web-ui| login screen.
 
-If there are a different number of disks connected to each |node|, an
-:ref:`Alert` is generated and the HA icon switches to
+If there are a different number of disks connected to each |ctrlr-term|,
+an :ref:`Alert` is generated and the HA icon switches to
 :guilabel:`HA Unavailable`.
 
 #endif truenas

--- a/userguide/tn_initial.rst
+++ b/userguide/tn_initial.rst
@@ -256,9 +256,9 @@ on the active computer.
 If the storage devices have been encrypted, a prompt appears for the
 passphrase. It must be correctly entered for the data on the disks to be
 accessible. If the system has also been licensed for High Availability
-(HA), the passphrase will be remembered as long as either |node| in the
-HA unit remains up. If both |nodes| are powered off, the passphrase must
-be re-entered when the first |node| powers back up.
+(HA), the passphrase will be remembered as long as either |ctrlr-term|
+in the HA unit remains up. If both |ctrlrs-term| are powered off, the
+passphrase must be re-entered when the first |ctrlr-term| powers back up.
 
 If the user interface is not accessible by IP address from a browser,
 check these things:

--- a/userguide/tn_initial.rst
+++ b/userguide/tn_initial.rst
@@ -256,9 +256,9 @@ on the active computer.
 If the storage devices have been encrypted, a prompt appears for the
 passphrase. It must be correctly entered for the data on the disks to be
 accessible. If the system has also been licensed for High Availability
-(HA), the passphrase will be remembered as long as either node in the HA
-unit remains up. If both nodes are powered off, the passphrase must be
-re-entered when the first node powers back up.
+(HA), the passphrase will be remembered as long as either |node| in the
+HA unit remains up. If both |nodes| are powered off, the passphrase must
+be re-entered when the first |node| powers back up.
 
 If the user interface is not accessible by IP address from a browser,
 check these things:

--- a/userguide/tn_options.rst
+++ b/userguide/tn_options.rst
@@ -163,7 +163,7 @@ verified that the scrub or resilver process is complete. Once
 complete, the shutdown request can be re-issued.
 
 On High Availability (HA) systems with :ref:`Failover`, an additional
-checkbox is provided to shut down the standby |node|.
+checkbox is provided to shut down the standby |ctrlr-term|.
 
 Click the :guilabel:`Cancel` button to cancel the shutdown request.
 Otherwise, click the :guilabel:`Shutdown` button to halt the system.

--- a/userguide/tn_options.rst
+++ b/userguide/tn_options.rst
@@ -163,7 +163,7 @@ verified that the scrub or resilver process is complete. Once
 complete, the shutdown request can be re-issued.
 
 On High Availability (HA) systems with :ref:`Failover`, an additional
-checkbox is provided to shut down the standby node.
+checkbox is provided to shut down the standby |node|.
 
 Click the :guilabel:`Cancel` button to cancel the shutdown request.
 Otherwise, click the :guilabel:`Shutdown` button to halt the system.


### PR DESCRIPTION
Register new replacements in conf.py
Search through the guide and replace every relevant instance of "node", "storage controller", and variants of the terms.
Current replacement term setting: "storage controller" and variants
TrueNAS html build testing: no related warnings
FreeNAS html build testing: no issues

cherry-pick #1135 and crunch on it a bit to get it working correctly for master branch