### PR TITLE
NAS-101771: Fix replacement error between angulargui and master branches

### DIFF
--- a/userguide/directoryservices.rst
+++ b/userguide/directoryservices.rst
@@ -204,7 +204,7 @@ advanced options.
    |                          |               |          |                                                                                                                               |
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
    | NetBIOS Name             | string        | ✓        | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the standby |ctrlr-term|.                 |
-   | (|Ctrlr-term-2|)         |               |          |                                                                                                                               |
+   | (|Ctrlr-term-1-2|)       |               |          |                                                                                                                               |
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
    | NetBIOS Alias            | string        | ✓        | Limited to 15 characters. When using :ref:`Failover`, this is the NetBIOS name that resolves to either |ctrlr-term|.          |
    #endif truenas


### PR DESCRIPTION
Update directoryservices.rst replacement to use |Ctrlr-term-1-2| in angulargui branch.
TrueNAS html build test: no issues.