### PR TITLE
NAS-102018 Add docs for cloud sync stop button

### DIFF
--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -158,6 +158,9 @@ These screen options have changed:
 * The :guilabel:`Periodic Notification User` field has been removed in
   :menuselection:`System --> Advanced`.
 
+* A :guilabel:`Stop` button for cloud sync tasks has been added to
+  :menuselection:`Tasks --> Cloud Sync`.
+
 * The :guilabel:`Follow symlinks` checkbox has been added to
   :menuselection:`Tasks --> Cloud Sync --> Add Cloud Sync`.
 

--- a/userguide/tasks.rst
+++ b/userguide/tasks.rst
@@ -218,7 +218,8 @@ with a status of *SUCCESS*.
 
 
 To modify an existing cloud sync, click the entry to access the
-:guilabel:`Edit`, and :guilabel:`Delete`, and :guilabel:`Run Now` buttons.
+:guilabel:`Edit`, :guilabel:`Delete`, :guilabel:`Run Now`, and
+:guilabel:`Stop` buttons.
 
 Click the :guilabel:`Status` column entry for a cloud sync that is
 *RUNNING*, *FAILED*, or a *SUCCESS*. This opens the log in a pop-up

--- a/userguide/tasks.rst
+++ b/userguide/tasks.rst
@@ -222,7 +222,7 @@ To modify an existing cloud sync, click the entry to access the
 :guilabel:`Stop` buttons.
 
 Click the :guilabel:`Status` column entry for a cloud sync that is
-*RUNNING*, *FAILED*, or a *SUCCESS*. This opens the log in a pop-up
+*RUNNING*, *FAILED*, *SUCCESS*, or *ABORTED*. This opens the log in a pop-up
 window to read any error messages or other details.
 
 


### PR DESCRIPTION
Note that the doc changes in the PR are purposely different from #1177 . This is because the slight difference in UI design.