### PR TITLE
NAS-102256: Update "Bind IP Addresses" in "Global SMB Configuration O…

### DIFF
--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1396,8 +1396,8 @@ screen is really a front-end to
    |                             |                   | in later versions of Windows.                                                                        |
    |                             |                   |                                                                                                      |
    +-----------------------------+-------------------+------------------------------------------------------------------------------------------------------+
-   | Bind IP Addresses           | checkboxes        | Static IPv4 and IPv6 addresses that SMB listens to for connections. Leaving the selection empty      |
-   |                             |                   | defaults to listening on all active interfaces.                                                      |
+   | Bind IP Addresses           | checkboxes        | IP addresses which SMB listens on for connections. Leaving all unselected defaults to listening on   |
+   |                             |                   | all active interfaces.                                                                               |
    |                             |                   |                                                                                                      |
    +-----------------------------+-------------------+------------------------------------------------------------------------------------------------------+
    | Idmap Range Low             | integer           | The beginning UID/GID for which this system is authoritative. Any UID/GID lower than this value      |

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1424,10 +1424,8 @@ screen is really a front-end to
    |                             |                   | in later versions of Windows.                                                                        |
    |                             |                   |                                                                                                      |
    +-----------------------------+-------------------+------------------------------------------------------------------------------------------------------+
-   | Bind IP Addresses           | checkboxes        | Select the IPv4 and IPv6 addresses SMB will listen on. Always add the loopback interface             |
-   |                             |                   | *127.0.0.1* as `Samba utilities connect to the loopback IP                                           |
-   |                             |                   | <https://wiki.samba.org/index.php/Configure_Sama_to_Bind_to_Specific_Interfaces>`__ if no host       |
-   |                             |                   | name is provided.                                                                                    |
+   | Bind IP Addresses           | checkboxes        | Static IPv4 and IPv6 addresses that SMB listens to for connections. Leaving the selection empty      |
+   |                             |                   | defaults to listening on all active interfaces.                                                      |
    |                             |                   |                                                                                                      |
    +-----------------------------+-------------------+------------------------------------------------------------------------------------------------------+
    | Idmap Range Low             | integer           | The beginning UID/GID for which this system is authoritative. Any UID/GID lower than this value      |


### PR DESCRIPTION
…ptions" table

- Remove obsolete text about loopback interfaces.
- Adapt current help text.
- Modify description to indicate static IP addresses can only be chosen.
- HTML build test: no issues.