### PR TITLE
NAS-102087: Add clarification about SMB share delete

### DIFF
--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -1198,6 +1198,9 @@ These VFS objects do not appear in the drop-down menu:
 To view all active SMB connections and users, enter :command:`smbstatus`
 in the :ref:`Shell`.
 
+Deleting an SMB share only removes the sharing settings. The dataset
+that was being shared is not affected.
+
 
 .. _Configuring Unauthenticated Access:
 

--- a/userguide/sharing.rst
+++ b/userguide/sharing.rst
@@ -1198,8 +1198,8 @@ These VFS objects do not appear in the drop-down menu:
 To view all active SMB connections and users, enter :command:`smbstatus`
 in the :ref:`Shell`.
 
-Deleting an SMB share only removes the sharing settings. The dataset
-that was being shared is not affected.
+Deleting an SMB share only removes the sharing settings. The data that
+was being shared is not affected.
 
 
 .. _Configuring Unauthenticated Access:


### PR DESCRIPTION
- No intro entry needed.
- Add text about what is or isn't removed when deleting an SMB share.
- HTML build test: no issues.