### PR TITLE
NAS-102561: Finish draft rewrite of Pool Encryption docs

### DIFF
--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -269,7 +269,7 @@ Managing Encrypted Pools
 
 %brand% uses
 `GELI <https://www.freebsd.org/cgi/man.cgi?query=geli>`__
-full disk encryption for ZFS pools. This type of encryption is primarily
+full disk encryption for ZFS pools. This type of encryption is
 intended to protect against the risks of data being read or copied when
 the system is powered down, when the pool is locked, or when disks are
 physically stolen.

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -267,76 +267,88 @@ The background color of the card indicates the pool status:
 Managing Encrypted Pools
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note:: %brand% uses
-   `GELI <https://www.freebsd.org/cgi/man.cgi?query=geli>`__
-   full disk encryption for ZFS pools. This type of encryption is
-   primarily intended to protect against the risks of data being read
-   or copied when the system is powered down, when the pool is locked,
-   or when disks are physically stolen.
+%brand% encrypts disks and pools, not individual filesystems. The
+partition table on each disk is not encrypted, but only identifies
+the location of partitions on the disk. On an encrypted pool, the data
+in each partition is encrypted. These are generally called
+"encrypted drives", even though the partition table is not encrypted. To
+use the drive firmware to completely encrypt the drive, see
+:ref:`Self-Encrypting Drives`.
 
-   Because data cannot be read without the key, encrypted disks
-   containing sensitive data can be safely removed, reused, or
-   discarded without secure wiping or physical destruction of the
-   media.
+#ifdef freenas
 
-   This encryption method is **not** designed to protect against
-   unauthorized access when the pool is already unlocked. Before
-   sensitive data is stored on the system, ensure that only authorized
-   users have access to the |web-ui| and that permissions with
-   appropriate restrictions are set on shares.
-
-
-Understanding the details of %brand% encryption is required to be able
-to use it effectively:
+.. note:: Processors with support for the
+   `AES-NI <https://en.wikipedia.org/wiki/AES_instruction_set>`__
+   instruction set are strongly recommended. These processors can
+   handle encryption of a small number of disks with negligible
+   performance impact. They also retain performance better as the
+   number of disks increases. Older processors without the AES-NI
+   instructions see significant performance impact with even a single
+   encrypted disk. This
+   `forum post <https://forums.freenas.org/index.php?threads/encryption-performance-benchmarks.12157/>`__
+   compares the performance of various processors.
 
 
-* %brand% encryption differs from the encryption used in Oracle's
-  proprietary version of ZFS. To convert between these formats, both
-  pools must be unlocked, and the data copied between them.
+#endif freenas
+%brand% uses
+`GELI <https://www.freebsd.org/cgi/man.cgi?query=geli>`__
+full disk encryption for ZFS pools. This type of encryption is primarily
+intended to protect against the risks of data being read or copied when
+the system is powered down, when the pool is locked, or when disks are
+physically stolen.
 
-* %brand% encrypts disks and pools, not individual filesystems. The
-  partition table on each disk is not encrypted, but only identifies
-  the location of partitions on the disk. On an encrypted pool, the
-  data in each partition is encrypted. These are generally called
-  "encrypted drives", even though the partition table is not
-  encrypted. To use the drive firmware to completely encrypt the
-  drive, see :ref:`Self-Encrypting Drives`.
+All drives in an encrypted pool are encrypted, including L2ARC (read
+cache) and SLOG (write cache). Drives added to an existing encrypted
+pool are encrypted with the same method specified when the pool was
+created. Data in memory, including ARC, is not encrypted.
 
-  Encrypted pools which do not have a passphrase are unlocked at
-  startup. Pools with a passphrase remain locked until the user
-  enters the passphrase to unlock them.
+Data in memory, including ARC, is not encrypted. ZFS data on disk,
+including L2ARC and SLOG, are encrypted if the underlying disks are
+encrypted. Swap data on disk is always encrypted.
 
-  Encrypted pools can be locked on demand by users with the passphrase.
-  They are automatically locked when the system is shut down.
+Encryption performance depends upon the number of disks encrypted. The
+more drives in an encrypted pool, the more encryption and decryption
+overhead, and the greater the impact on performance. **Encrypted pools
+composed of more than eight drives can suffer severe performance
+penalties**. If encryption is desired, please benchmark such pools
+before using them in production.
 
-* This type of encryption is primarily useful for users wanting the
-  ability to remove disks from the pool without having to first wipe
-  the disks of any sensitive data.
+When an encrypted pool is created, GELI encrypts the data on the disk
+and generates a *master key* to decrypt this data. This master key is
+also encrypted. Loss of a disk master key due to disk corruption is
+equivalent to any other disk failure, and in a redundant pool, other
+disks will contain accessible copies of the uncorrupted data. While it
+is *possible* to separately back up disk master keys, it is usually not
+necessary or useful.
 
-* When discarding disks that still contain encrypted sensitive data,
-  the encryption key must also be destroyed or securely deleted.  If
-  the encryption key is not destroyed, it must be stored securely and
-  kept physically separate from the discarded disks. If the encryption
-  key is present on or with the discarded disks, or can be obtained by
-  the same person who gains access to the disks, the data will be
-  vulnerable to decryption.
+There are two *user keys* that can be used to unlock the
+master key and then decrypt the disks. In %brand%, these user keys
+are named the **encryption key** and the **recovery key**.
 
-* Protect the key with a strong passphrase and store all key backups
-  securely. If the encryption key is lost, the data on the disks is
-  inaccessible. Always back up the key!
+Because data cannot be read without first providing a key, encrypted
+disks containing sensitive data can be safely removed, reused, or
+discarded without secure wiping or physical destruction of the media.
 
-* Each pool has a separate encryption key. Technical details about how
-  encryption key use, storage, and management are described in this
-  `forum post <https://forums.freenas.org/index.php?threads/recover-encryption-key.16593/#post-85497>`__.
+When discarding disks that still contain encrypted sensitive data, the
+encryption and recovery keys must also be destroyed or securely deleted.
+If these keys are not destroyed, they must be stored securely and kept
+physically separate from the discarded disks. If the encryption key is
+present on or with the discarded disks, or can be obtained by the same
+person who gains access to the disks, the data will be vulnerable to
+decryption.
 
-* Data in memory, including ARC, is not encrypted. ZFS data on disk,
-  including ZIL and SLOG, are encrypted if the underlying disks are
-  encrypted. Swap data on disk is always encrypted.
+This encryption method is **not** designed to protect against
+unauthorized access when the pool is already unlocked. Before sensitive
+data is stored on the system, ensure that only authorized users have
+access to the |web-ui| and that permissions with appropriate
+restrictions are set on shares.
 
-* All drives in an encrypted pool are encrypted, including L2ARC (read
-  cache) and SLOG (write cache). Drives added to an existing encrypted
-  pool are encrypted with the same method specified when the pool was
-  created. Data in memory, including ARC, is not encrypted.
+%brand% encryption differs from the encryption used in Oracle's
+proprietary version of ZFS. To convert between these formats, both pools
+must be unlocked, and the data copied between them.
+
+Here are some important points about %brand% behavior to remember when
+creating or using an encrypted pool:
 
 * At present, there is no one-step way to encrypt an existing pool.
   The data must be copied to an existing or new encrypted pool.
@@ -348,37 +360,38 @@ to use it effectively:
   encryption scheme. :ref:`Extending a Pool` automatically encrypts a
   new vdev being added to an existing encrypted pool.
 
-Encryption performance depends upon the number of disks encrypted. The
-more drives in an encrypted pool, the more encryption and decryption
-overhead, and the greater the impact on performance.
-**Encrypted pools composed of more than eight drives can suffer severe
-performance penalties**.
-If encryption is desired, please benchmark such pools before using
-them in production.
-#ifdef freenas
+* Each pool has a separate encryption key. Pools can also add a unique
+  recovery key to use if the passphrase is forgotten or encryption key
+  invalidated.
 
-.. note:: Processors with support for the
-   `AES-NI <https://en.wikipedia.org/wiki/AES_instruction_set>`__
-   instruction set are strongly recommended. These processors can
-   handle encryption of a small number of disks with negligible
-   performance impact. They also retain performance better as the
-   number of disks increases. Older processors without the AES-NI
-   instructions see significant performance impact with even a single
-   encrypted disk. This `forum post
-   <https://forums.freenas.org/index.php?threads/encryption-performance-benchmarks.12157/>`__
-   compares the performance of various processors.
+* Encryption applies to a pool, not individual users. The data from an
+  unlocked pool is accessible to all users with permissions to access
+  it. Encrypted pools with a passphrase can be locked on demand by users
+  that know the passphrase. Pools are automatically locked when the
+  system is shut down.
 
-#endif freenas
+* Encrypted data cannot be accessed when the disks are removed or the
+  system has been shut down. On a running system, encrypted data cannot
+  be accessed when the pool is locked.
 
-%brand% generates and stores a randomized *encryption key* whenever
-a new encrypted pool is created. This key is required to read and
-decrypt any data on the pool.
+* Encrypted pools that have no passphrase are unlocked at startup. Pools
+  with a passphrase remain locked until a user enters the passphrase
+  to unlock them.
 
-Encryption keys can also be downloaded as a safety measure, to allow
-decryption on a different system in the event of failure, or to allow
-the locally stored key to be deleted for extra security. Encryption
-keys can be optionally protected with a *passphrase* for additional
-security. The combination of encryption key location and whether a
+
+.. _Encryption and Recovery Keys:
+
+Encryption and Recovery Keys
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+%brand% generates a randomized *encryption key* whenever a new encrypted
+pool is created. This key is stored in the
+:ref:`system dataset <System Dataset>`. It is the primary key used to
+unlock the pool each time the system boots. Creating a passphrase for
+the pool also modifies the encryption key. Keys can be downloaded as a
+safety measure, to allow disk decryption on a different system in the
+event of failure, or to allow the locally stored key to be deleted for
+extra security. The combination of encryption key location and whether a
 passphrase is used provide several different security scenarios:
 
 * *Key stored locally, no passphrase*: the encrypted pool is decrypted
@@ -394,136 +407,114 @@ passphrase is used provide several different security scenarios:
   can be accessed (`two factor authentication
   <https://en.wikipedia.org/wiki/Multi-factor_authentication>`__).
 
-Encrypted data cannot be accessed when the disks are removed or the
-system has been shut down. On a running system, encrypted data
-cannot be accessed when the pool is locked and the key is not available.
-If the key is protected with a passphrase, both the key and passphrase
-are required for decryption.
+Encrypted pools cannot be locked until a passphrase is created for the
+encryption key. This passphrase is required to :guilabel:`Lock` and
+:guilabel:`Unlock` the pool.
 
-Encryption applies to a pool, not individual users. When a pool is
-unlocked, data is accessible to all users with permissions to access
-it.
+The recovery key is an optional keyfile that is generated by %brand%,
+provided for download, and wiped from the system. This file is not
+stored anywhere on the %brand% system. The recovery key file is designed
+as an emergency backup to unlock or import an encrypted pool if the
+passphrase is forgotten or the encryption key is somehow invalidated.
+Only one recovery key can exist for each encrypted pool. Adding a new
+recovery key invalidates any previously downloaded recovery key file for
+that pool.
 
-.. note:: `GELI <https://www.freebsd.org/cgi/man.cgi?query=geli>`__
-   uses *two* randomized encryption keys for each disk. The first has
-   been discussed here. The second, the disk "master key", is
-   encrypted and stored in the on-disk GELI metadata. Loss of a disk
-   master key due to disk corruption is equivalent to any other disk
-   failure, and in a redundant pool, other disks will contain
-   accessible copies of the uncorrupted data. While it is *possible*
-   to separately back up disk master keys, it is usually not necessary
-   or useful.
+Existing encryption or recovery keys can be invalidated in several
+situations:
 
+* An encryption re-key invalidates all encryption and recovery keys as
+  well as an existing passphrase.
 
-To manage the passphrase and keys on an encrypted pool, select the
-pool name in
-:menuselection:`Storage --> Pools`,
-click |pool-lock|, and select one of these operations:
+* Using the recovery key to import an encrypted pool invalidates the
+  existing encryption key and passphrase for that pool.
 
-**Lock:** Only appears after a passphrase has been created. When a pool
-is locked, the data is not accessible until the pool is unlocked by
-supplying the passphrase. For this reason, selecting this action
-requires entering the passphrase. When the pool is locked, the status
-changes to *LOCKED (Locked Used / Locked Free)*.
-:guilabel:`Pool Operations` are limited to *Export/Disconnect*, and
-|pool-lock| changes to |pool-unlock|.
+* Creating or changing a passphrase invalidates any existing recovery
+  key.
 
-Unlock the pool by clicking the |pool-unlock| icon and entering
-the passphrase *or* use the :guilabel:`Browse` button to load the
-recovery key. Only the passphrase is used when both a passphrase and a
-recovery key are entered. The services listed in
-:guilabel:`Restart Services` will restart when the pool is unlocked.
-This allows them to see the new pool and share or access data on it.
-Individual services can be prevented from restarting by clicking the
-:guilabel:`Restart Services` drop-down and unselecting them. However,
-a service that is not restarted might not be able to access the unlocked
-pool.
+* Adding a new recovery key invalidates any existing recovery key files
+  for the pool.
 
-The passphrase for a pool can be changed by clicking
-|pool-lock| :menuselection:`--> Change Passphrase`.
-To change the passphrase, enter the :guilabel:`Root Password` and a
-new :guilabel:`Passphrase`. To remove the passphrase from the pool,
-set :guilabel:`Remove passphrase`.
+Be sure to download and securely store copies of the most current
+encryption and recovery keys. Protect and backup encryption key
+passphrases. **Losing the encryption and recovery keys or the passphrase
+can result in irrevocably losing all access to the data stored in the
+encrypted pool!**
 
 
-**Create Passphrase:** set and confirm a passphrase associated with the
-GELI encryption key.
+.. _Encryption Operations:
 
-#ifdef comment
-# not visible in UI yet
-A red warning is a reminder to
-:guilabel:`Remember to add a new recovery key` as this action
-invalidates the previous recovery key`.
-#endif comment
+Encryption Operations
+^^^^^^^^^^^^^^^^^^^^^
 
-Unlike a password, a passphrase can contain spaces and is typically a
-series of words. A good passphrase is easy to remember (like the line
-to a song or piece of literature) but hard to guess (people you know
-should not be able to guess the passphrase). **Remember this
-passphrase. An encrypted pool cannot be reimported without it.** In
-other words, if the passphrase is forgotten, the data on the pool can
-become inaccessible if it becomes necessary to reimport the pool.
-Protect this passphrase, as anyone who knows it could reimport the
-encrypted pool, thwarting the reason for encrypting the disks in the
-first place.
+Encryption operations display by selecting the pool name in
+:menuselection:`Storage --> Pools`
+and clicking |pool-lock|. These options are available:
 
-.. _zfs_encrypt_passphrase_fig:
+* :guilabel:`Lock`: Only appears after a passphrase is created. Locking
+  a pool restricts data accessability in %brand% until the pool is
+  unlocked by a user supplying the passphrase or uploading the recovery
+  key file.
 
-.. figure:: images/storage-pools-encrypt-passphrase.png
+  Selecting this action requires entering the passphrase. The pool
+  status changes to :literal:`LOCKED`, :guilabel:`Pool Operations` are
+  limited to *Export/Disconnect*, and |pool-lock| changes to
+  |pool-unlock|.
 
-   Add a Passphrase to an Encrypted Pool
+* :guilabel:`Unlock`: Decrypt the pool by clicking the |pool-unlock|
+  icon and entering the passphrase *or* uploading the recovery key. Only
+  the passphrase is used when both a passphrase and a recovery key are
+  entered. The services listed in :guilabel:`Restart Services` restart
+  when the pool is unlocked. This enables %brand% to begin accessing
+  the decrypted data. Individual services can be prevented from
+  restarting by opening :guilabel:`Restart Services` and deselecting
+  them. Warning: This can prevent services from properly accessing the
+  unlocked pool.
 
+* :guilabel:`Create Passphrase`: Add a passphrase to the encryption key.
+  Unlike a password, a passphrase can contain spaces and is typically a
+  series of words. A good passphrase is easy to remember but hard to
+  guess.
 
-After the passphrase is set, the name of this button changes to
-:guilabel:`Change Passphrase` and the :guilabel:`Root Password` is also
-required to change the passphrase. After setting or changing the
-passphrase, it is important to *immediately* create a new recovery key
-by clicking the :guilabel:`Add Recovery Key` button. This way, if the
-passphrase is forgotten, the associated recovery key can be used
-instead.
+  .. _zfs_encrypt_passphrase_fig:
 
-**Add Recovery Key:** generate a new recovery key. This screen
-prompts for the %brand% administrative password and then the directory
-in which to save the key. Note that the recovery key is saved to the
-client system, not on the %brand% system. This recovery key can be
-used if the passphrase is forgotten. **Always immediately add a
-recovery key whenever the passphrase is changed.**
+  .. figure:: images/storage-pools-encrypt-passphrase.png
 
-**Delete Recovery Key:** Typically this is only performed when the
-administrator suspects that the current recovery key may be
-compromised. **Immediately** create a new passphrase and recovery key.
-
-.. note:: Protect the passphrase, recovery key, and encryption key.
-   Do not reveal the passphrase to others. On the system
-   containing the downloaded keys, take care that the system and its
-   backups are protected. Anyone who has the keys has the ability to
-   re-import the disks if they are discarded or stolen.
+     Add a Passphrase to an Encrypted Pool
 
 
-.. warning:: If a re-key fails on a multi-disk system, an alert is
-   generated. **Do not ignore this alert** as doing so may result in
-   the loss of data.
+  Creating a passphrase changes this button to
+  :guilabel:`Change Passphrase`. The administrator password is also
+  required to change the passphrase. Setting
+  :guilabel:`Remove Passphrase` invalidates the current pool passphrase.
+  Creating or changing a passphrase invalidates previously downloaded
+  recovery key files for this pool.
 
+* :guilabel:`Add Recovery Key`: Generate a new recovery key. This screen
+  prompts for the %brand% administrative password. The recovery key is
+  only saved to the client system. This recovery key can be used to
+  unlock or import the pool if the passphrase is forgotten.
 
-**Encryption Rekey:** generate a new GELI encryption key. Typically
-this is only performed when the administrator suspects that the
-current key may be compromised. This action also removes the current
-passphrase.
+* :guilabel:`Delete Recovery Key`: Invalidate any previously downloaded
+  recovery key files for this pool.
+
+* :guilabel:`Encryption Rekey`: This resets the encryption on the GELI
+  master key and invalidates all encryption keys, recovery keys, and
+  passphrase for the pool. A dialog opens to save a backup of the new
+  encryption key. Create a new passphrase to enable locking the pool and
+  add a recovery key to replace any previously generated recovery key.
+
+  If a re-key fails on a multi-disk system, an alert is generated. **Do
+  not ignore this alert** as doing so may result in the loss of data.
 #ifdef truenas
 
-.. note:: A re-key is not allowed if :ref:`Failover`
-   (High Availability) has been enabled and the standby |ctrlr-term| is
-   down.
+  .. note:: A re-key is not allowed if :ref:`Failover`
+     (High Availability) has been enabled and the standby |ctrlr-term|
+     is down.
 #endif truenas
 
-**Download Encrypt Key:** download a backup copy of the GELI encryption
-key. The encryption key is saved to the client system, not on the
-%brand% system. The %brand% administrative password must be entered,
-then the directory in which to store the key is chosen. Since the GELI
-encryption key is separate from the %brand% configuration database,
-**it is highly recommended to make a backup of the key. If the key is
-ever lost or destroyed and there is no backup key, the data on the
-disks is inaccessible.**
+* :guilabel:`Download Encrypt Key`: Opens a dialog to download a copy of
+  the encryption key.
 
 
 .. _Adding Cache or Log Devices:

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -465,7 +465,7 @@ These options are available:
   when the pool is unlocked. This enables %brand% to begin accessing
   the decrypted data. Individual services can be prevented from
   restarting by opening :guilabel:`Restart Services` and deselecting
-  them. However, this can prevent those services from properly accessing
+  them. Deselecting services can prevent them from properly accessing
   the unlocked pool.
 
 * :guilabel:`Create Passphrase`: Add a passphrase to the encryption key.

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -1042,8 +1042,10 @@ System Dataset
 shown in
 :numref:`Figure %s <system_dataset_fig>`,
 is used to select the pool which contains the persistent system
-dataset. The system dataset stores debugging core files and Samba4
-metadata such as the user/group cache and share level permissions.
+dataset. The system dataset stores debugging core files,
+:ref:`encryption keys <Encryption and Recovery Keys>` for encrypted
+pools, and Samba4 metadata such as the user/group cache and share level
+permissions.
 
 .. note:: When the system dataset is moved, a new dataset is created
    and set active. The old dataset is intentionally not deleted by


### PR DESCRIPTION
- text is ready for review/refinement.
- All behaviors have been verified in 11.3 Beta1 except using the recovery key file to import an encrypted pool. That test is being held up by an unrelated bug.
- HTML build test: no issues.