### PR TITLE
NAS-100007: Add entry for AD related alerts

### DIFF
--- a/userguide/snippets/alertevents.rst
+++ b/userguide/snippets/alertevents.rst
@@ -93,7 +93,7 @@ Some of the conditions that trigger an alert include:
 
 * hardware events detected by an attached :ref:`IPMI` controller
 
-* error found with the :ref:`Active Directory` connection
+* an error with the :ref:`Active Directory` connection
 
 * ZFS pool status changes from :guilabel:`HEALTHY`
 

--- a/userguide/snippets/alertevents.rst
+++ b/userguide/snippets/alertevents.rst
@@ -93,6 +93,8 @@ Some of the conditions that trigger an alert include:
 
 * hardware events detected by an attached :ref:`IPMI` controller
 
+* error found with the :ref:`Active Directory` connection
+
 * ZFS pool status changes from :guilabel:`HEALTHY`
 
 * a S.M.A.R.T. error occurs


### PR DESCRIPTION
- Investigated directoryservices.rst and found text related to the alerts was already present.
- As previously discussed, no intro entry is necessary.
- HTML build test: no issues.