### PR TITLE
NAS-102301: Add general usage note about expanding list entries

### DIFF
--- a/userguide/booting.rst
+++ b/userguide/booting.rst
@@ -98,26 +98,23 @@ The |web-ui| is displayed after login:
 
 The rest of this User Guide describes the %brand% |web-ui| in
 more detail. The layout of this User Guide follows the order of the menu
-items in the tree located in the left frame of the |web-ui|. Here are
-some notes about using the |web-ui|:
+items in the tree located in the left frame of the |web-ui|.
 
-* Lists can be configured to show different columns by default. When
-  there are hidden columns in a list, entries can be expanded with
-  |ui-chevron-right| to show all available information about that entry.
+.. _Using the |Web-UI|:
 
-* To keep lists aligned when using zoom in Firefox, ensure
-  :menuselection:`View --> Zoom --> Zoom Text Only`
-  is not set.
+Using the |Web-UI|
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* It is important to use the |web-ui| or the Console Setup menu for all
-  configuration changes. %brand% uses a configuration database to store
-  its settings. While it is possible to use the command line to modify
-  the configuration, changes made at the command line **are not**
-  written to the configuration database. This means that any changes
-  made at the command line will not persist after a reboot and will be
-  overwritten by the values in the configuration database during an
-  upgrade.
+Lists can be configured to show different columns by default. When there
+are hidden columns in a list, entries can be expanded with
+|ui-chevron-right| to show all available information about that entry.
 
+It is important to use the |web-ui| or the Console Setup menu for all
+configuration changes. %brand% uses a configuration database to store
+settings. Commands entered at the command line **do not modify the
+settings database**. This means that any changes made at the command
+line will not persist after a reboot and will be overwritten by the
+values in the configuration database during an upgrade.
 
 If the %brand% system does not respond to the IP address or mDNS name
 entered in a browser:

--- a/userguide/booting.rst
+++ b/userguide/booting.rst
@@ -96,24 +96,28 @@ The |web-ui| is displayed after login:
    %brand% Graphical Configuration Menu
 
 
-#ifdef freenas
 The rest of this User Guide describes the %brand% |web-ui| in
 more detail. The layout of this User Guide follows the order of the menu
-items in the tree located in the left frame of the |web-ui|.
+items in the tree located in the left frame of the |web-ui|. Here are
+some notes about using the |web-ui|:
 
-.. note:: To keep lists aligned when using zoom in Firefox, ensure
-   :menuselection:`View --> Zoom --> Zoom Text Only`
-   is not set.
+* Lists can be configured to show different columns by default. When
+  there are hidden columns in a list, entries can be expanded with
+  |ui-chevron-right| to show all available information about that entry.
 
-.. note:: It is important to use the |web-ui| or the Console Setup
-   menu for all configuration changes. %brand% uses a configuration
-   database to store its settings. While it is possible to use the
-   command line to modify the configuration, changes made at the
-   command line **are not** written to the configuration database.
-   This means that any changes made at the command line will not
-   persist after a reboot and will be overwritten by the values in the
-   configuration database during an upgrade.
-#endif freenas
+* To keep lists aligned when using zoom in Firefox, ensure
+  :menuselection:`View --> Zoom --> Zoom Text Only`
+  is not set.
+
+* It is important to use the |web-ui| or the Console Setup menu for all
+  configuration changes. %brand% uses a configuration database to store
+  its settings. While it is possible to use the command line to modify
+  the configuration, changes made at the command line **are not**
+  written to the configuration database. This means that any changes
+  made at the command line will not persist after a reboot and will be
+  overwritten by the values in the configuration database during an
+  upgrade.
+
 
 If the %brand% system does not respond to the IP address or mDNS name
 entered in a browser:

--- a/userguide/booting.rst
+++ b/userguide/booting.rst
@@ -99,36 +99,3 @@ The |web-ui| is displayed after login:
 The rest of this User Guide describes the %brand% |web-ui| in
 more detail. The layout of this User Guide follows the order of the menu
 items in the tree located in the left frame of the |web-ui|.
-
-.. _Using the |Web-UI|:
-
-Using the |Web-UI|
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Lists can be configured to show different columns by default. When there
-are hidden columns in a list, entries can be expanded with
-|ui-chevron-right| to show all available information about that entry.
-
-It is important to use the |web-ui| or the Console Setup menu for all
-configuration changes. %brand% uses a configuration database to store
-settings. Commands entered at the command line **do not modify the
-settings database**. This means that any changes made at the command
-line will not persist after a reboot and will be overwritten by the
-values in the configuration database during an upgrade.
-
-If the %brand% system does not respond to the IP address or mDNS name
-entered in a browser:
-
-* Check for enabled proxy settings in the browser configuration, disable
-  them, and try connecting again.
-
-* :command:`ping` the %brand% system IP address from another computer
-  on the same network.
-
-* Try a different web browser if the user interface loads but is
-  unresponsive or seems to be missing menu items.
-  `Firefox <https://www.mozilla.org/en-US/firefox/all/>`__ is
-  recommended.
-
-* Make sure that the browser is set to allow cookies from the
-  %brand% system.

--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -441,6 +441,40 @@ Path and Name Lengths
 #include snippets/pathlengths.rst
 
 
+.. _Using the |Web-UI|:
+
+Using the |Web-UI|
+----------------------------
+
+Lists can be configured to show different columns by default. When there
+are hidden columns in a list, entries can be expanded with
+|ui-chevron-right| to show all available information about that entry.
+
+It is important to use the |web-ui| or the Console Setup menu for all
+configuration changes. %brand% uses a configuration database to store
+settings. Commands entered at the command line **do not modify the
+settings database**. This means that any changes made at the command
+line will not persist after a reboot and will be overwritten by the
+values in the configuration database during an upgrade.
+
+If the %brand% system does not respond to the IP address or mDNS name
+entered in a browser:
+
+* Check for enabled proxy settings in the browser configuration, disable
+  them, and try connecting again.
+
+* :command:`ping` the %brand% system IP address from another computer
+  on the same network.
+
+* Try a different web browser if the user interface loads but is
+  unresponsive or seems to be missing menu items.
+  `Firefox <https://www.mozilla.org/en-US/firefox/all/>`__ is
+  recommended.
+
+* Make sure that the browser is set to allow cookies from the
+  %brand% system.
+
+
 .. index:: Hardware Recommendations
 .. _Hardware Recommendations:
 

--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -440,39 +440,7 @@ Path and Name Lengths
 
 #include snippets/pathlengths.rst
 
-
-.. _Using the |Web-UI|:
-
-Using the |Web-UI|
-----------------------------
-
-Lists can be configured to show different columns by default. When there
-are hidden columns in a list, entries can be expanded with
-|ui-chevron-right| to show all available information about that entry.
-
-It is important to use the |web-ui| or the Console Setup menu for all
-configuration changes. %brand% uses a configuration database to store
-settings. Commands entered at the command line **do not modify the
-settings database**. This means that any changes made at the command
-line will not persist after a reboot and will be overwritten by the
-values in the configuration database during an upgrade.
-
-If the %brand% system does not respond to the IP address or mDNS name
-entered in a browser:
-
-* Check for enabled proxy settings in the browser configuration, disable
-  them, and try connecting again.
-
-* :command:`ping` the %brand% system IP address from another computer
-  on the same network.
-
-* Try a different web browser if the user interface loads but is
-  unresponsive or seems to be missing menu items.
-  `Firefox <https://www.mozilla.org/en-US/firefox/all/>`__ is
-  recommended.
-
-* Make sure that the browser is set to allow cookies from the
-  %brand% system.
+#include snippets/usingui.rst
 
 
 .. index:: Hardware Recommendations

--- a/userguide/snippets/usingui.rst
+++ b/userguide/snippets/usingui.rst
@@ -1,0 +1,58 @@
+.. _Using the Web Interface:
+
+Using the |Web-UI|
+------------------
+
+
+Tables and Columns
+~~~~~~~~~~~~~~~~~~
+
+Tables show a subset of all available columns. Additional columns can
+be shown or hidden with the :guilabel:`COLUMNS` button. Set a
+checkmark by the fields to be shown in the table. Column settings are
+remembered from session to session.
+
+The original columns can be restored by clicking
+:guilabel:`Reset to Defaults` in the column list.
+
+Each row in a table can be expanded to show all the information by
+clicking the |ui-chevron-right| button.
+
+
+Changing %brand% Settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is important to use the |web-ui| or the Console Setup menu for all
+configuration changes. %brand% stores configuration settings in a
+database. Commands entered at the command line
+**do not modify the settings database**. This means that changes made
+at the command line will be lost after a restart and overwritten by
+the values in the settings database.
+
+
+|Web-UI| Troubleshooting
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+If the |web-ui| is shown but seems unresponsive or incomplete:
+
+* Make sure the browser allows cookies, Javascript, and custom fonts
+  from the %brand% system.
+
+* Try a different browser.
+  `Firefox <https://www.mozilla.org/en-US/firefox/all/>`__
+  is recommended.
+
+
+If a web browser cannot connect to the %brand% system by IP address,
+DNS hostname, or mDNS name:
+
+
+* Check or disable proxy settings in the browser.
+
+* Verify the network connection by pinging the %brand% system by IP
+  address from another computer on the same network. For example, if
+  the %brand% system is at IP address 192.168.1.19, enter
+  :samp:`ping {192.168.1.19}` on the command line of the other
+  computer. If there is no response, check network configuration.
+


### PR DESCRIPTION
- Rework two existing note boxes in booting.rst to make a list of UI usage suggestions
- Remove unnecessary FreeNAS ifdefs from the section.
- HTML build tests: no issues.