### PR TITLE
 NAS-102623: Small update to Network/Interfaces 'IP Address' description.

### DIFF
--- a/userguide/network.rst
+++ b/userguide/network.rst
@@ -255,7 +255,7 @@ which settings are available with each interface type.
    |                     |                |             | which support jumbo frames. See :ref:`this note <LAGG_MTU>` about MTU and lagg interfaces.                |
    |                     |                |             |                                                                                                           |
    +---------------------+----------------+-------------+-----------------------------------------------------------------------------------------------------------+
-   | IP Address          | integer and    | All         | Static IPv4 or IPv6 address and subnet mask. Example: *10.0.0.3* and *22*. Click :guilabel:`ADD`          |
+   | IP Address          | integer and    | All         | Static IPv4 or IPv6 address and subnet mask. Example: *10.0.0.3* and *24*. Click :guilabel:`ADD`          |
    |                     | drop-down menu |             | to add another IP address. Clicking :guilabel:`DELETE` removes that :guilabel:`IP Address`.               |
    +---------------------+----------------+-------------+-----------------------------------------------------------------------------------------------------------+
 

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -201,9 +201,9 @@ settings.
    |                      |                |                                                                                                                          |
    +----------------------+----------------+--------------------------------------------------------------------------------------------------------------------------+
 
-
-After making any changes, click :guilabel:`SAVE`. Changing any |web-ui|
-settings opens a dialog to reset the %brand% web service.
+After making any changes, click :guilabel:`SAVE`. Changes to
+:guilabel:`WebGUI` fields can interrupt |web-ui| connectivity while the
+new settings are applied.
 
 This screen also contains these buttons:
 

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -201,9 +201,9 @@ settings.
    |                      |                |                                                                                                                          |
    +----------------------+----------------+--------------------------------------------------------------------------------------------------------------------------+
 
-After making any changes, click :guilabel:`SAVE`. Changes to
-:guilabel:`WebGUI` fields can interrupt |web-ui| connectivity while the
-new settings are applied.
+
+After making any changes, click :guilabel:`SAVE`. Changing any |web-ui|
+settings opens a dialog to reset the %brand% web service.
 
 This screen also contains these buttons:
 


### PR DESCRIPTION
Update example to show default subnet mask.
Confirm VIP descriptions are correct for subnet 32.
HTML build testing: no issues.