### PR TITLE
NAS-102879: Expand update in progress text

### DIFF
--- a/userguide/conf.py
+++ b/userguide/conf.py
@@ -124,6 +124,7 @@ rst_prolog = u'''
 .. |ui-refresh|           replace::  (Refresh)
 .. |ui-settings|          replace::  (Settings)
 .. |ui-task-manager|      replace::  (Task Manager)
+.. |ui-update|            replace:: 
 .. |usb-stick|            replace:: USB stick
 .. |usb-sticks|           replace:: USB sticks
 .. |web-ui|               replace:: web interface

--- a/userguide/intro.rst
+++ b/userguide/intro.rst
@@ -194,6 +194,9 @@ These screen options have changed:
   :ref:`Global Configuration` are shown under the iXsystems logo at the
   top left of the |web-ui|.
 
+* The |web-ui| now indicates when a
+  :ref:`system update is in progress <Update in Progress>`.
+
 * The :guilabel:`Theme Selector` has been removed from the top
   navigation bar. The theme is now selected in :ref:`Preferences`.
 

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -1994,7 +1994,6 @@ Update
 %brand% has an integrated update system to make it easy to keep up to
 date.
 
-
 .. _Preparing for Updates:
 
 Preparing for Updates
@@ -2224,9 +2223,6 @@ confirmation window. Setting :guilabel:`Confirm` and clicking
    Review the boot environments and remove the *Keep* attribute or
    delete any boot environments that are no longer needed.
 
-During the update process a progress dialog appears. **Do not**
-interrupt the update until it completes.
-
 
 Manual Updates
 ~~~~~~~~~~~~~~
@@ -2265,8 +2261,18 @@ The current version of %brand% is shown for verification.
 Select the manual update file with the :guilabel:`Browse` button. Set
 :guilabel:`Reboot After Update` to reboot the system after the update
 has been installed. Click :guilabel:`APPLY UPDATE` to begin the
-update. A progress dialog is displayed during the update. **Do not**
-interrupt the update.
+update.
+
+
+.. _Update in Progress:
+
+Update in Progress
+~~~~~~~~~~~~~~~~~~~
+
+Starting an update shows a progress dialog. When an update is in
+progress, the |web-ui| shows an |ui-update| icon in the top row. Dialogs
+also appear in every active |web-ui| session to warn that a system
+update is in progress. **Do not** interrupt a system update.
 
 
 #ifdef truenas


### PR DESCRIPTION
- Move duplicate text into a separate subsection in System/Update docs.
- Add new icon replacement in conf.py
- Expand text about what happens after an update is started.
- Add intro entry pointed to new subsection.