### PR TITLE
NAS-103528: Clean up remaining mentions of Graphite.

### DIFF
--- a/userguide/reporting.rst
+++ b/userguide/reporting.rst
@@ -109,9 +109,3 @@ Data files are saved in :file:`/var/db/collectd/rrd/`.
 
 .. warning:: Reporting data is frequently written and should not be
    stored on the boot pool or |os-device|.
-
-
-`Update on using Graphite with FreeNAS
-<http://cmhramblings.blogspot.com/2015/12/update-on-using-graphite-with-freenas.html>`__
-contains instructions for sending the collected information to a
-`Graphite <http://graphiteapp.org/>`__ server.

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -1103,8 +1103,8 @@ These settings are described in
    | Report CPU usage    | checkbox  | Report CPU usage in percent instead of units of     |
    | in percent          |           | kernel time.                                        |
    +---------------------+-----------+-----------------------------------------------------+
-   | Graphite Server     | string    | Destination hostname or IP address for collectd     |
-   |                     |           | data sent by the Graphite plugin.                   |
+   | Remote Graphite     | string    | IP address or hostname of a remote server running   |
+   | Server Hostname     |           | `Graphite <http://graphiteapp.org/>`__.             |
    +---------------------+-----------+-----------------------------------------------------+
    | Graph Age           | integer   | Maximum time a graph is stored in months.           |
    |                     |           | Changing this value causes the                      |

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -1103,8 +1103,8 @@ These settings are described in
    | Report CPU usage    | checkbox  | Report CPU usage in percent instead of units of     |
    | in percent          |           | kernel time.                                        |
    +---------------------+-----------+-----------------------------------------------------+
-   | Remote Graphite     | string    | IP address or hostname of a remote server running   |
-   | Server Hostname     |           | `Graphite <http://graphiteapp.org/>`__.             |
+   | Remote Graphite     | string    | Hostname or IP address of a remote                  |
+   | Server Hostname     |           | `Graphite <http://graphiteapp.org/>`__ server.      |
    +---------------------+-----------+-----------------------------------------------------+
    | Graph Age           | integer   | Maximum time a graph is stored in months.           |
    |                     |           | Changing this value causes the                      |


### PR DESCRIPTION
- Remove obsolete sentence in reporting.rst
- Reapply original field name and description for System/Reporting `Graphite Server` option.
- Requires syncing with webui repo.
- HTML build test: no issues.