### PR TITLE
DOCS-90: Update TrueNAS guide to use correct active/standby controlle…

### DIFF
--- a/userguide/conf.py
+++ b/userguide/conf.py
@@ -90,7 +90,7 @@ rst_prolog = u'''
 .. |ctrlrs-term-both|     replace:: active and standby TrueNAS controllers
 .. |active|               replace:: active
 .. |standby|              replace:: standby
-.. |actv-stndby|          replace:: active/standby
+.. |active-standby|       replace:: active/standby
 .. |dockerhost|           replace:: Docker VM
 .. |help-pin|             replace::  (Pin)
 .. |help-text|            replace::  (Help Text)

--- a/userguide/conf.py
+++ b/userguide/conf.py
@@ -87,6 +87,10 @@ rst_prolog = u'''
 .. |ctrlr-term-1-2|       replace:: TrueNAS controller 1/2
 .. |ctrlr-term-active|    replace:: active TrueNAS controller
 .. |ctrlr-term-standby|   replace:: standby TrueNAS controller
+.. |ctrlrs-term-both|     replace:: active and standby TrueNAS controllers
+.. |active|               replace:: active
+.. |standby|              replace:: standby
+.. |actv-stndby|          replace:: active/standby
 .. |dockerhost|           replace:: Docker VM
 .. |help-pin|             replace::  (Pin)
 .. |help-text|            replace::  (Help Text)

--- a/userguide/directoryservices.rst
+++ b/userguide/directoryservices.rst
@@ -192,12 +192,12 @@ advanced options.
    #endif freenas
    #ifdef truenas
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
-   | NetBIOS Name             | string        | ✓        | Name for the computer object generated in AD. Automatically populated with the active |ctrlr-term| hostname from the          |
+   | NetBIOS Name             | string        | ✓        | Name for the computer object generated in AD. Automatically populated with the |ctrlr-term-active| hostname from the          |
    |                          |               |          | :ref:`Global Configuration`. Limited to 15 characters. It **must** be different from the *Workgroup* name.                    |
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
-   | NetBIOS Name             | string        | ✓        | Name for the computer object generated in AD. Automatically populated with the standby |ctrlr-term| hostname from the         |
-   | (|Ctrlr-term-1-2|)       |               |          | :ref:`Global Configuration`. Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the standby  |
-   |                          |               |          | |ctrlr-term|.                                                                                                                 |
+   | NetBIOS Name             | string        | ✓        | Name for the computer object generated in AD. Automatically populated with the |ctrlr-term-standby| hostname from the         |
+   | (|Ctrlr-term-1-2|)       |               |          | :ref:`Global Configuration`. Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the          |
+   |                          |               |          | |ctrlr-term-standby|.                                                                                                         |
    +--------------------------+---------------+----------+-------------------------------------------------------------------------------------------------------------------------------+
    | NetBIOS Alias            | string        | ✓        | Limited to 15 characters. When using :ref:`Failover`, this is the NetBIOS name that resolves to either |ctrlr-term|.          |
    #endif truenas
@@ -502,7 +502,7 @@ Those new to LDAP terminology should read the
    |                         |                |          |                                                                                                     |
    +-------------------------+----------------+----------+-----------------------------------------------------------------------------------------------------+
    | NetBIOS Name            | string         | ✓        | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the             |
-   | (|Ctrlr-term-2|)        |                |          | standby |ctrlr-term|.                                                                               |
+   | (|Ctrlr-term-2|)        |                |          | |ctrlr-term-standby|.                                                                               |
    |                         |                |          |                                                                                                     |
    +-------------------------+----------------+----------+-----------------------------------------------------------------------------------------------------+
    | NetBIOS Alias           | string         | ✓        | Limited to 15 characters. When using :ref:`Failover`, this is the NetBIOS name that resolves        |

--- a/userguide/services.rst
+++ b/userguide/services.rst
@@ -1191,12 +1191,12 @@ These options are described in
    +----------------------------------+----------------+-------------------------------------------------------------------------------------------------------+
    #endif freenas
    #ifdef truenas
-   | NetBIOS Name                     | string         | Automatically populated with the active |ctrlr-term| hostname from the :ref:`Global Configuration`.   |
+   | NetBIOS Name                     | string         | Automatically populated with the |ctrlr-term-active| hostname from the :ref:`Global Configuration`.   |
    |                                  |                | Limited to 15 characters. It **must** be different from the *Workgroup* name.                         |
    +----------------------------------+----------------+-------------------------------------------------------------------------------------------------------+
-   | NetBIOS Name                     | string         | Automatically populated with the standby |ctrlr-term| hostname from the :ref:`Global Configuration`.  |
-   | (|Ctrlr-term-1-2|)               |                | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the standby       |
-   |                                  |                | |ctrlr-term|.                                                                                         |
+   | NetBIOS Name                     | string         | Automatically populated with the |ctrlr-term-standby| hostname from the :ref:`Global Configuration`.  |
+   | (|Ctrlr-term-1-2|)               |                | Limited to 15 characters. When using :ref:`Failover`, set a unique NetBIOS name for the               |
+   |                                  |                | |ctrlr-term-standby|.                                                                                 |
    +----------------------------------+----------------+-------------------------------------------------------------------------------------------------------+
    | NetBIOS Alias                    | string         | Limited to 15 characters. When using :ref:`Failover`, this is the NetBIOS name that resolves          |
    |                                  |                | to either |ctrlr-term|.                                                                               |

--- a/userguide/snippets/alertevents.rst
+++ b/userguide/snippets/alertevents.rst
@@ -162,18 +162,18 @@ Some of the conditions that trigger an alert include:
 
 * one |ctrlr-term| of an HA pair gets stuck applying its configuration
   journal as this condition could block future configuration changes
-  from being applied to the standby |ctrlr-term|
+  from being applied to the |ctrlr-term-standby|
 
 * |ctrlrs-term| do not have the same number of connected disks
 
-* the boot volume of the passive |ctrlr-term| is not HEALTHY
+* the boot volume of the |ctrlr-term-standby| is not HEALTHY
 
 * 30 days before the license expires, and when the license expires
 
 * the usage of a HA link goes above 10MB/s
 
-* an IPMI query to a standby |ctrlr-term| fails, indicating the standby
-  |ctrlr-term| is down
+* an IPMI query to a |ctrlr-term-standby| fails, indicating the
+  |ctrlr-term-standby| is down
 
 * :ref:`Proactive Support` is enabled but any of the configuration
   fields are empty
@@ -187,7 +187,7 @@ Some of the conditions that trigger an alert include:
 * if a USB storage device has been attached which could prevent
   booting or failover
 
-* when the passive |ctrlr-term| cannot be contacted
+* when the |ctrlr-term-standby| cannot be contacted
 
 * when it is 180, 90, 30, or 14 days before support contract
   expiration

--- a/userguide/snippets/ui_login.rst
+++ b/userguide/snippets/ui_login.rst
@@ -50,7 +50,7 @@ about the |ctrlr-term-active| is displayed on this screen. Log in with:
 On the first login, the EULA found in :ref:`Appendix A` is displayed,
 along with a box where the license key for the %brand% array can be
 pasted. Read the EULA and paste in the license key. High Availability
-(HA) systems must have both |ctrlrs-term-both| booted before the license
+(HA) systems must have both |ctrlrs-term-both| running before the license
 key for the HA %brand% system can be entered. The key is entered on the
 |ctrlr-term-active|. Click :guilabel:`OK` to save the license key and
 access the |web-ui|.

--- a/userguide/snippets/ui_login.rst
+++ b/userguide/snippets/ui_login.rst
@@ -31,7 +31,7 @@ The |web-ui| is displayed after login:
 #endif freenas
 #ifdef truenas
 The :ref:`High Availability (HA) <Failover>` status and information
-about the active |ctrlr-term| is displayed on this screen. Log in with:
+about the |ctrlr-term-active| is displayed on this screen. Log in with:
 
 * :guilabel:`Username`: :samp:`root`
 
@@ -50,10 +50,10 @@ about the active |ctrlr-term| is displayed on this screen. Log in with:
 On the first login, the EULA found in :ref:`Appendix A` is displayed,
 along with a box where the license key for the %brand% array can be
 pasted. Read the EULA and paste in the license key. High Availability
-(HA) systems must have both active and standby |ctrlrs-term| booted
-before the license key for the HA %brand% system can be entered. The key
-is entered on the active |ctrlr-term|. Click :guilabel:`OK` to save the
-license key and access the |web-ui|.
+(HA) systems must have both |ctrlrs-term-both| booted before the license
+key for the HA %brand% system can be entered. The key is entered on the
+|ctrlr-term-active|. Click :guilabel:`OK` to save the license key and
+access the |web-ui|.
 #endif truenas
 
 .. _login_dashboard_fig:

--- a/userguide/storage.rst
+++ b/userguide/storage.rst
@@ -25,10 +25,10 @@ these options:
 
 #ifdef truenas
 .. note:: When using an HA (High Availability) %brand% system,
-   connecting to the |web-ui| on the passive |ctrlr-term| only
-   shows a screen indicating that it is the passive |ctrlr-term|. All of
+   connecting to the |web-ui| on the |ctrlr-term-standby| only
+   shows a screen indicating that it is the |ctrlr-term-standby|. All of
    the options discussed in this chapter can only be configured on the
-   active |ctrlr-term|.
+   |ctrlr-term-active|.
 #endif truenas
 
 
@@ -523,7 +523,7 @@ These options are available:
 #ifdef truenas
 
   .. note:: A key reset is not allowed if :ref:`Failover`
-     (High Availability) has been enabled and the standby |ctrlr-term|
+     (High Availability) has been enabled and the |ctrlr-term-standby|
      is down.
 #endif truenas
 

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -1001,7 +1001,7 @@ that volume is no longer allowed to be locked or have a passphrase set.
 
 Moving the system dataset also requires
 #ifdef truenas
-rebooting the passive |ctrlr-term| for :ref:`High Availability <Failover>`
+rebooting the |ctrlr-term-standby| for :ref:`High Availability <Failover>`
 %brand% systems and
 #endif truenas
 restarting the :ref:`SMB` service. A dialog warns that the SMB service
@@ -2661,15 +2661,15 @@ Failover
 When the %brand% array has been licensed for High Availability (HA),
 a :guilabel:`Failover` option appears in :guilabel:`System`.
 
-%brand% uses an active/standby configuration of dual |ctrlrs-term| for
+%brand% uses an |actv-stndby| configuration of dual |ctrlrs-term| for
 HA. Dual-ported disk drives are connected to both |ctrlrs-term|
-simultaneously. One |ctrlr-term| is active, the other standby. The
-active |ctrlr-term| sends periodic announcements to the network. If a
-fault occurs and the active |ctrlr-term| stops sending the announcements,
-the standby |ctrlr-term| detects this and initiates a failover. Storage
-and cache devices are imported on the standby |ctrlr-term|, then I/O
-operations switch over to it. The standby |ctrlr-term| then becomes the
-active |ctrlr-term|. This failover operation can happen in seconds
+simultaneously. One |ctrlr-term| is |active|, the other |standby|. The
+|ctrlr-term-active| sends periodic announcements to the network. If a
+fault occurs and the |ctrlr-term-active| stops sending the announcements,
+the |ctrlr-term-standby| detects this and initiates a failover. Storage
+and cache devices are imported on the |ctrlr-term-standby|, then I/O
+operations switch over to it. The |ctrlr-term-standby| then becomes the
+|ctrlr-term-active|. This failover operation can happen in seconds
 rather than the minutes of other configurations, significantly reducing
 the chance of a client timeout.
 
@@ -2701,12 +2701,12 @@ virtual IP can be configured. An extra drop-down is added to
 :guilabel:`IPMI` to allow configuring :ref:`IPMI` for each |ctrlr-term|.
 The
 :menuselection:`Dashboard`
-also updates to add an entry for the passive |ctrlr-term|. This entry
+also updates to add an entry for the |ctrlr-term-standby|. This entry
 includes a button to manually initiate a failover.
 
-Fields modified by activating the HA license use *1* or *2* to identify
-the |ctrlrs-term|. These numbers correspond to the |ctrlr-term| labels
-on the %brand% chassis.
+Fields modified by activating the HA license use *1*, *2*, or
+|actv-stndby| to identify the |ctrlrs-term|. These numbers correspond to
+the |ctrlr-term| labels on the %brand% chassis.
 
 To :ref:`configure HA networking <Global Configuration>`, go to
 :menuselection:`Network --> Global Configuration`.
@@ -2758,12 +2758,12 @@ and click :guilabel:`ADD`. The HA license adds several fields to the
 After the network configuration is complete, log out and log back in,
 this time using the virtual IP address. Pools and shares can now be
 configured as usual and configuration automatically synchronizes between
-the active and the standby |ctrlr-term|.
+the |ctrlrs-term-both|.
 
 All subsequent logins should use the virtual IP address. Connecting
-directly to the passive or standby |ctrlr-term| with a browser does not
-allow |web-ui| logins. The screen shows the HA status, |ctrlr-term|
-state, and the configuration management virtual IP address.
+directly to the |ctrlr-term-standby| with a browser does not allow
+|web-ui| logins. The screen shows the HA status, |ctrlr-term| state, and
+the configuration management virtual IP address.
 
 .. _HA icon:
 
@@ -2771,7 +2771,7 @@ After HA is configured, an :guilabel:`HA Enabled` icon appears in the
 upper-right section of the |web-ui|
 
 When HA is disabled by the system administrator, the status icon
-changes to :guilabel:`HA Disabled`. If the standby |ctrlr-term| is not
+changes to :guilabel:`HA Disabled`. If the |ctrlr-term-standby| is not
 available because it is powered off, still starting up, disconnected
 from the network, or if failover has not been configured, the status
 icon changes to :guilabel:`HA Unavailable`.
@@ -2798,22 +2798,22 @@ The remaining failover options are found in
    |                   |                |                                                                                                                                                    |
    +===================+================+====================================================================================================================================================+
    | Disabled          | checkbox       | Disables failover. Activates the :guilabel:`Master` checkbox. The :guilabel:`HA Enabled` icon changes to :guilabel:`HA Disabled`.                  |
-   |                   |                | An error message is generated if the standby |ctrlr-term| is not responding or failover is not configured.                                         |
+   |                   |                | An error message is generated if the |ctrlr-term-standby| is not responding or failover is not configured.                                         |
    |                   |                |                                                                                                                                                    |
    +-------------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
-   | Master            | checkbox       | Only available when :guilabel:`Disabled` is set. Set to mark the currently active |ctrlr-term| as *master*. The *master* |ctrlr-term|              |
-   |                   |                | is the default *active* controller when both |ctrlrs-term| are online and HA is enabled.                                                           |
+   | Master            | checkbox       | Only available when :guilabel:`Disabled` is set. Set to mark the current |ctrlr-term-active| as *master*. The *master* |ctrlr-term|                |
+   |                   |                | is the default |ctrlr-term-active| when both |ctrlrs-term| are online and HA is enabled.                                                           |
    +-------------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
    | Timeout           | integer        | Number of seconds to wait after a network failure before triggering a failover. *0* indicates that a failover either occurs immediately or after   |
    |                   |                | two seconds when the system is using a link aggregation.                                                                                           |
    +-------------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
-   | SYNC TO PEER      | button         | Force synchronizing the %brand% configuration from the active                                                                                      |
-   |                   |                | |ctrlr-term| to the standby |ctrlr-term|. The standby |ctrlr-term| must be rebooted after the synchronization is complete to                       |
+   | SYNC TO PEER      | button         | Force synchronizing the %brand% configuration from the                                                                                             |
+   |                   |                | |ctrlr-term-active| to the |ctrlr-term-standby|. The |ctrlr-term-standby| must be rebooted after the synchronization is complete to                |
    |                   |                | load the new configuration. Synchronization occurs automatically in %brand% and this option is only used when troubleshooting                      |
    |                   |                | HA configurations. **Do not use this unless requested by an iXsystems Support Engineer.**                                                          |
    +-------------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
-   | SYNC FROM PEER    | button         | Force synchronizing the %brand% configuration from the standby                                                                                     |
-   |                   |                | |ctrlr-term| to the active |ctrlr-term|. Synchronization occurs automatically in %brand% and this option is only used                              |
+   | SYNC FROM PEER    | button         | Force synchronizing the %brand% configuration from the                                                                                             |
+   |                   |                | |ctrlr-term-standby| to the |ctrlr-term-active|. Synchronization occurs automatically in %brand% and this option is only used                      |
    |                   |                | when troubleshooting HA configurations. **Do not use this unless requested by an iXsystems Support Engineer.**                                     |
    +-------------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
 
@@ -2821,7 +2821,7 @@ The remaining failover options are found in
 **Notes about High Availability and failovers:**
 
 Booting an HA pair with failover disabled causes both |ctrlrs-term| to
-come up in standby mode. The |web-ui| shows an additional
+come up in |standby| mode. The |web-ui| shows an additional
 :guilabel:`Force Takeover` button which can be used to force that
 |ctrlr-term| to take control.
 

--- a/userguide/system.rst
+++ b/userguide/system.rst
@@ -2661,7 +2661,7 @@ Failover
 When the %brand% array has been licensed for High Availability (HA),
 a :guilabel:`Failover` option appears in :guilabel:`System`.
 
-%brand% uses an |actv-stndby| configuration of dual |ctrlrs-term| for
+%brand% uses an |active-standby| configuration of dual |ctrlrs-term| for
 HA. Dual-ported disk drives are connected to both |ctrlrs-term|
 simultaneously. One |ctrlr-term| is |active|, the other |standby|. The
 |ctrlr-term-active| sends periodic announcements to the network. If a
@@ -2705,8 +2705,8 @@ also updates to add an entry for the |ctrlr-term-standby|. This entry
 includes a button to manually initiate a failover.
 
 Fields modified by activating the HA license use *1*, *2*, or
-|actv-stndby| to identify the |ctrlrs-term|. These numbers correspond to
-the |ctrlr-term| labels on the %brand% chassis.
+|active-standby| to identify the |ctrlrs-term|. These numbers correspond
+to the |ctrlr-term| labels on the %brand% chassis.
 
 To :ref:`configure HA networking <Global Configuration>`, go to
 :menuselection:`Network --> Global Configuration`.

--- a/userguide/tn_options.rst
+++ b/userguide/tn_options.rst
@@ -163,7 +163,7 @@ verified that the scrub or resilver process is complete. Once
 complete, the shutdown request can be re-issued.
 
 On High Availability (HA) systems with :ref:`Failover`, an additional
-checkbox is provided to shut down the standby |ctrlr-term|.
+checkbox is provided to shut down the |ctrlr-term-standby|.
 
 Click the :guilabel:`Cancel` button to cancel the shutdown request.
 Otherwise, click the :guilabel:`Shutdown` button to halt the system.


### PR DESCRIPTION
…r terminology.

- Add new substitutions to cover a few edge cases for the standard terms.
- Grep through all the .rst files and change every found instance of active, passive, standby controller to the new substitutions.
- TrueNAS HTML build test: no issues.