### PR TITLE
rclone sync delete failures w/ s3 glacier

### DIFF
--- a/userguide/tasks.rst
+++ b/userguide/tasks.rst
@@ -1785,6 +1785,10 @@ files from the destination:
   adjust the
   `Backblaze B2 Lifecycle Rules <https://www.backblaze.com/blog/backblaze-b2-lifecycle-rules/>`__
 
+* Files stored in Amazon S3 Glacier or S3 Glacier Deep Archive cannot be deleted by 
+  `rclone sync <https://rclone.org/s3/#glacier-and-glacier-deep-archive/>`__. 
+  These files must first  be restored by another means e.g. AWS Console. 
+
 To modify an existing cloud sync, click |ui-options| to access the
 :guilabel:`Run Now`, :guilabel:`Edit`, and :guilabel:`Delete` options.
 


### PR DESCRIPTION
In addition to the two failure modes already listed, a third failure mode occurs when files are stored in S3 Glacier or Glacier Deep Archive storage classes.